### PR TITLE
feat: prompt ayar sayfalarında native editor ve preview-only etkili promptlar

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -52,32 +52,31 @@ All global settings live under **Administration → AI Code Reviewer → Configu
 
 ## Administrative Pages
 
-The plugin installs five administrative screens under **Administration → AI Code Reviewer**. Each page is backed by the correspo
-nding REST resource so you can also integrate the functionality into automation tooling.
+The plugin installs five administrative screens under **Administration → AI Code Reviewer**. Each page is backed by the corresponding
+REST resource so you can also integrate the functionality into automation tooling.
 
 ### Configuration
 
 - **Purpose**: establish global defaults, manage model connectivity, and define guardrails that apply across all projects.
 - **Layout**:
-  - **Connection card**: configure primary and fallback Ollama endpoints, transport timeouts, and the service account used to po
-st comments. The **Test connection** action validates credentials and latency before you commit changes.
-  - **Review behaviour card**: tune chunking limits, retry policies, and severity filters. Inline validation warns when values e
-xceed supported thresholds or conflict with project overrides.
-  - **Guardrails card**: manage concurrency ceilings, queue limits, and repository scope (all/allow list/block list). When the c
-urrent queue is close to the configured limits the UI displays warning badges so you can react before requests are rejected.
+  - **Connection card**: configure primary and fallback Ollama endpoints, transport timeouts, and the service account used to post
+  comments. The **Test connection** action validates credentials and latency before you commit changes.
+  - **Review behaviour card**: tune chunking limits, retry policies, and severity filters. Inline validation warns when values exceed
+  supported thresholds or conflict with project overrides.
+  - **Guardrails card**: manage concurrency ceilings, queue limits, and repository scope (all/allow list/block list). When the current
+  queue is close to the configured limits the UI displays warning badges so you can react before requests are rejected.
   - **Overrides table**: lists repositories with custom settings and highlights keys that deviate from the global defaults. From
- here you can open the repository override dialog or navigate to the REST endpoint for scripted updates.
+  here you can open the repository override dialog or navigate to the REST endpoint for scripted updates.
 - **Usage tips**:
   - Save changes in small batches and export the configuration JSON afterwards for audit purposes.
-  - When enabling review of draft pull requests or increasing chunk limits, coordinate with the infrastructure team to ensure t
-he Ollama backend has enough capacity.
+  - When enabling review of draft pull requests or increasing chunk limits, coordinate with the infrastructure team to ensure the
+  Ollama backend has enough capacity.
   - Use the **Effective settings** fly-out to troubleshoot why a specific repository is behaving differently; it merges global,
- project, and repository overrides in precedence order.
+  project, and repository overrides in precedence order.
 
 ### Prompt Customisation
 
-- **Purpose**: manage the prompts sent to the model and review the effective prompt payloads after defaults and append instructi
-ons are applied.
+- **Purpose**: manage the prompts sent to the model and review the effective prompt payloads after defaults and append instructions are applied.
 - **Key sections**:
   - **Effective System Prompt**: preview-only view of the final system prompt (including `prompt.system.append`).
   - **Effective User Prompt**: preview-only view of the final user prompt (including repository append instructions).
@@ -92,18 +91,18 @@ ons are applied.
 
 - **Purpose**: audit review execution and re-run analyses outside the pull request context.
 - **Key sections**:
-  - **Filters**: slice by project, repository, status, trigger type, reviewer cohort, or date range. Filters persist across sess
-ions per administrator to speed up investigations.
-  - **Timeline table**: lists the last 90 days of runs with timestamps, duration, triggering actor, commit hash, and the count o
-f findings posted. Status badges highlight guardrail skips versus provider failures.
-  - **Detail drawer**: selecting a run reveals chunk-level telemetry, retry attempts, and links to raw provider transcripts (obf
-uscated for PII) for compliance review.
+  - **Filters**: slice by project, repository, status, trigger type, reviewer cohort, or date range. Filters persist across sessions
+  per administrator to speed up investigations.
+  - **Timeline table**: lists the last 90 days of runs with timestamps, duration, triggering actor, commit hash, and the count of
+  findings posted. Status badges highlight guardrail skips versus provider failures.
+  - **Detail drawer**: selecting a run reveals chunk-level telemetry, retry attempts, and links to raw provider transcripts (obfuscated for PII)
+  for compliance review.
   - **Actions**: rerun a review, cancel an in-progress execution, or purge stored artifacts for the selected pull request. These
- actions call the `/history/manual`, `/progress/admin/cancel`, and `/history/purge` REST routes respectively.
+  actions call the `/history/manual`, `/progress/admin/cancel`, and `/history/purge` REST routes respectively.
 - **Usage tips**:
   - Use the history table during incident response to quantify impact (number of failed runs, repositories affected).
   - Export CSV snapshots when preparing change management records or audits; exports include the configuration checksum applied
- to each run.
+  to each run.
   - When comparing runs, sort by commit hash to confirm that regressions correspond to specific pushes.
 
 ### Health Dashboard
@@ -111,30 +110,27 @@ uscated for PII) for compliance review.
 - **Purpose**: monitor the health of the AI review service and its dependencies.
 - **Widgets**:
   - **Service connectivity**: shows the last successful call to each configured model, average latency, and failure trends. The
- UI flags HTTP error codes, TLS negotiation issues, or authentication failures.
-  - **Worker pool utilisation**: visualises queue depth, active workers, and throttle states aggregated from `GuardrailsWorkerNo
-deState` records.
-  - **Guardrail status**: summarises rate-limit enforcement, repository allow/block list hits, and burst credit consumption so y
-ou can identify systemic throttling.
-  - **Event log**: stream of notable events (fallback activation, circuit breaker trips, manual pauses) with links to related re
-st endpoints for quick remediation.
+  UI flags HTTP error codes, TLS negotiation issues, or authentication failures.
+  - **Worker pool utilisation**: visualises queue depth, active workers, and throttle states aggregated from `GuardrailsWorkerNodeState` records.
+  - **Guardrail status**: summarises rate-limit enforcement, repository allow/block list hits, and burst credit consumption so you
+  can identify systemic throttling.
+  - **Event log**: stream of notable events (fallback activation, circuit breaker trips, manual pauses) with links to related REST
+  endpoints for quick remediation.
 - **Usage tips**:
-  - Investigate spikes in request latency before developers encounter timeouts. The chart retains 24 hours of history for trend
- analysis.
+  - Investigate spikes in request latency before developers encounter timeouts. The chart retains 24 hours of history for trend analysis.
   - Use the **Download diagnostics** button to collect the latest health snapshot and attach it to support tickets.
-  - If a node stops reporting heartbeats, drain the scheduler and failover traffic before restarting the affected application no
-de.
+  - If a node stops reporting heartbeats, drain the scheduler and failover traffic before restarting the affected application node.
 
 ### Operations Console
 
 - **Purpose**: perform privileged actions that affect the scheduler, queue, and rollout cadence.
 - **Capabilities**:
-  - **Scheduler controls**: pause, resume, or drain the review scheduler. Pausing prevents new runs while letting active jobs fi
-nish; draining stops scheduling and cancels remaining queue entries.
-  - **Rollout management**: assign repositories or projects to rollout cohorts, set cohort-specific guardrails, and schedule gra
-dual enablement windows. The console surfaces the REST payloads so you can mirror changes in infrastructure-as-code.
-  - **Alerting and burst credits**: configure webhook or e-mail alert channels, acknowledge incident notifications, and grant bu
-rst credits when teams need temporary capacity boosts.
+  - **Scheduler controls**: pause, resume, or drain the review scheduler. Pausing prevents new runs while letting active jobs finish;
+  draining stops scheduling and cancels remaining queue entries.
+  - **Rollout management**: assign repositories or projects to rollout cohorts, set cohort-specific guardrails, and schedule gradual
+  enablement windows. The console surfaces the REST payloads so you can mirror changes in infrastructure-as-code.
+  - **Alerting and burst credits**: configure webhook or e-mail alert channels, acknowledge incident notifications, and grant burst
+  credits when teams need temporary capacity boosts.
   - **Data hygiene**: trigger cleanup jobs, purge stale history, or archive AI responses to S3 via configured automations.
 - **Usage tips**:
   - Always pause the scheduler before performing Bitbucket maintenance or rotating Ollama credentials to avoid partial runs.

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -52,7 +52,7 @@ All global settings live under **Administration → AI Code Reviewer → Configu
 
 ## Administrative Pages
 
-The plugin installs four administrative screens under **Administration → AI Code Reviewer**. Each page is backed by the correspo
+The plugin installs five administrative screens under **Administration → AI Code Reviewer**. Each page is backed by the correspo
 nding REST resource so you can also integrate the functionality into automation tooling.
 
 ### Configuration
@@ -73,6 +73,20 @@ urrent queue is close to the configured limits the UI displays warning badges so
 he Ollama backend has enough capacity.
   - Use the **Effective settings** fly-out to troubleshoot why a specific repository is behaving differently; it merges global,
  project, and repository overrides in precedence order.
+
+### Prompt Customisation
+
+- **Purpose**: manage the prompts sent to the model and review the effective prompt payloads after defaults and append instructi
+ons are applied.
+- **Key sections**:
+  - **Effective System Prompt**: preview-only view of the final system prompt (including `prompt.system.append`).
+  - **Effective User Prompt**: preview-only view of the final user prompt (including repository append instructions).
+  - **User Prompt Override**: optional replacement for the default user prompt template (`prompt.chunk`).
+  - **System Prompt Additions**: text appended to the system prompt (`prompt.system.append`).
+- **Usage tips**:
+  - Keep changes small and validate results in a staging environment before rolling out globally.
+  - Use the effective previews to confirm that placeholders and append instructions render as expected.
+  - Combine this page with repository-level overrides when a specific repo needs tailored instructions.
 
 ### Review History
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -35,6 +35,7 @@ This reference lists the configuration keys managed by `AIReviewerConfigService`
 | `ignorePaths` | Global/Repo | String CSV | `node_modules/,vendor/,build/,dist/,.git/` | Directory prefixes to ignore. |
 | `aiReviewerUser` | Global/Repo | String | *(empty)* | Optional Bitbucket username used to author AI comments. If blank, the triggering user is impersonated. |
 | `workerDegradationEnabled` | Global | Bool | `true` | Allow worker pool to throttle itself when saturation persists. |
+| `verboseMode` | Global | Bool | `false` | When enabled, prompt payloads are written to `${java.io.tmpdir}/ai-reviewer/verbose/<PROJECT>/<REPO>/pr-<ID>/chunk-<ID>-<timestamp>.json` for troubleshooting. |
 
 ## Chunking & Retries
 
@@ -91,6 +92,22 @@ Additional prompt keys:
 
 - `prompt.system.append` (Global/Repo): Appends additional text to the default system prompt.
 - `prompt.chunk.append` (Repo or Global): Appends repository-specific instructions to the user prompt.
+
+### Prompt template placeholders (user prompt overrides)
+
+When you override the user prompt (`prompt.chunk`), you can use these replaceable placeholders. They are replaced at runtime by the prompt renderer.
+
+| Placeholder | Description |
+| --- | --- |
+| `{{OVERVIEW}}` | Repository + pull request overview summary for the review run. |
+| `{{MIN_SEVERITY}}` | The minimum severity string derived from the active review profile (e.g. `low`, `medium`). |
+| `{{CHUNK_CONTEXT}}` | Context block describing the current chunk (file names and metadata for the chunk). |
+| `{{ANNOTATED_DIFF}}` | The current diff chunk with line markers (e.g. `[Line 42]`) that the model should reference. |
+
+Notes:
+
+- These placeholders are intended for the user prompt template (`prompt.chunk`).
+- The system prompt uses `{{ADDITIONAL_INSTRUCTIONS}}` internally when system prompt additions are configured.
 
 ## Derived Metadata
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -35,7 +35,7 @@ This reference lists the configuration keys managed by `AIReviewerConfigService`
 | `ignorePaths` | Global/Repo | String CSV | `node_modules/,vendor/,build/,dist/,.git/` | Directory prefixes to ignore. |
 | `aiReviewerUser` | Global/Repo | String | *(empty)* | Optional Bitbucket username used to author AI comments. If blank, the triggering user is impersonated. |
 | `workerDegradationEnabled` | Global | Bool | `true` | Allow worker pool to throttle itself when saturation persists. |
-| `verboseMode` | Global | Bool | `false` | When enabled, prompt payloads are written to `${java.io.tmpdir}/ai-reviewer/verbose/<PROJECT>/<REPO>/pr-<ID>/chunk-<ID>-<timestamp>.json` for troubleshooting. |
+| `verboseMode` | Global | Bool | `false` | When enabled, prompt payloads are written during active AI reviews to `${java.io.tmpdir}/ai-reviewer/verbose/<PROJECT>/<REPO>/pr-<ID>/chunk-<ID>-<timestamp>.json` for troubleshooting. Files are created per chunk; if no review runs, no files are emitted. In containerized deployments, check the JVM temp directory inside the Bitbucket container. |
 
 ## Chunking & Retries
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -87,6 +87,11 @@ Repository overrides implicitly define scope membership when `scopeMode` is not 
 
 Keys beginning with `prompt` (for example `prompt.system`, `prompt.overview`, `prompt.chunk`) accept multi-line strings to override the bundled templates stored in `src/main/resources/prompts`. They are validated for size and for unsafe placeholders before saving.
 
+Additional prompt keys:
+
+- `prompt.system.append` (Global/Repo): Appends additional text to the default system prompt.
+- `prompt.chunk.append` (Repo or Global): Appends repository-specific instructions to the user prompt.
+
 ## Derived Metadata
 
 - `aiReviewerUserDisplayName` is computed by the service when returning configuration and cannot be set manually.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -35,7 +35,7 @@ This reference lists the configuration keys managed by `AIReviewerConfigService`
 | `ignorePaths` | Global/Repo | String CSV | `node_modules/,vendor/,build/,dist/,.git/` | Directory prefixes to ignore. |
 | `aiReviewerUser` | Global/Repo | String | *(empty)* | Optional Bitbucket username used to author AI comments. If blank, the triggering user is impersonated. |
 | `workerDegradationEnabled` | Global | Bool | `true` | Allow worker pool to throttle itself when saturation persists. |
-| `verboseMode` | Global | Bool | `false` | When enabled, prompt payloads are written during active AI reviews to `${java.io.tmpdir}/ai-reviewer/verbose/<PROJECT>/<REPO>/pr-<ID>/chunk-<ID>-<timestamp>.json` for troubleshooting. Files are created per chunk; if no review runs, no files are emitted. In containerized deployments, check the JVM temp directory inside the Bitbucket container. |
+| `verboseMode` | Global | Bool | `false` | When enabled, prompt payloads are written during active AI reviews to `${java.io.tmpdir}/ai-reviewer/verbose/<PROJECT>/<REPO>/pr-<ID>/chunk-<ID>-<timestamp>.json` for troubleshooting. Files are created per chunk; if no review runs, no files are emitted. The plugin prunes verbose payloads after 200 files per PR or 7 days (override with JVM properties `ai.reviewer.verbose.maxFiles` and `ai.reviewer.verbose.maxAgeDays`). In containerized deployments, check the JVM temp directory inside the Bitbucket container. |
 
 ## Chunking & Retries
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -93,6 +93,11 @@ Additional prompt keys:
 - `prompt.system.append` (Global/Repo): Appends additional text to the default system prompt.
 - `prompt.chunk.append` (Repo or Global): Appends repository-specific instructions to the user prompt.
 
+Prompt management is also available in the UI:
+
+- **Administration → AI Code Reviewer → Prompt Customisation** shows effective system/user prompts and lets administrators override `prompt.chunk` and `prompt.system.append`.
+- **Repository settings → AI Code Reviewer Prompt Settings** lets repository admins override `prompt.chunk` and add repository-specific `prompt.chunk.append` instructions.
+
 ### Prompt template placeholders (user prompt overrides)
 
 When you override the user prompt (`prompt.chunk`), you can use these replaceable placeholders. They are replaced at runtime by the prompt renderer.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -48,6 +48,16 @@ For repository-level configuration details and administrative tooling (Configura
 - Push a new commit: the listener automatically reschedules a differential review of the new changes.
 - Ask a system administrator to trigger a manual run via the Operations page or the `/rest/ai-reviewer/1.0/history/manual` endpoint.
 
+## Repository Prompt Settings
+
+Repository administrators can fine-tune prompts for a single repository via **Repository settings → AI Code Reviewer Prompt Settings**.
+
+- **Effective user prompt**: preview-only view of the final user prompt after global defaults and repository append instructions are applied.
+- **User prompt override**: replace the global user prompt template for this repository only.
+- **Additional instructions**: append repository-specific guidance to the user prompt. These appear under the `ADDITIONAL INSTRUCTIONS:` heading in the effective prompt.
+
+Use this page when a repository needs specialized review guidance without changing global settings.
+
 ## Best Practices
 
 - Keep pull requests under the configured size limits (files, diff size, chunk count) to avoid guardrail throttling.

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/OllamaAiReviewClient.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/OllamaAiReviewClient.java
@@ -28,12 +28,16 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -518,6 +522,7 @@ public class OllamaAiReviewClient implements AiReviewClient {
                 chunk,
                 overview,
                 annotatedDiff);
+    writeVerbosePrompt(context, chunk, model, overview, annotatedDiff, templates.getSystemPrompt(), userPrompt, truncated);
 
         Map<String, Object> request = new LinkedHashMap<>();
         request.put("model", model);
@@ -533,6 +538,47 @@ public class OllamaAiReviewClient implements AiReviewClient {
             return OBJECT_MAPPER.writeValueAsString(request);
         } catch (Exception ex) {
             throw new IllegalStateException("Failed to serialise request", ex);
+        }
+    }
+
+    private void writeVerbosePrompt(ReviewContext context,
+                                    ReviewChunk chunk,
+                                    String model,
+                                    String overview,
+                                    String annotatedDiff,
+                                    String systemPrompt,
+                                    String userPrompt,
+                                    boolean truncated) {
+        if (context == null || context.getConfig() == null || !context.getConfig().isVerboseMode()) {
+            return;
+        }
+        try {
+            String baseDir = System.getProperty("java.io.tmpdir", "/tmp");
+            String projectKey = context.getPullRequest().getToRef().getRepository().getProject().getKey();
+            String repoSlug = context.getPullRequest().getToRef().getRepository().getSlug();
+            long prId = context.getPullRequest().getId();
+            Path dir = Paths.get(baseDir, "ai-reviewer", "verbose", projectKey, repoSlug, "pr-" + prId);
+            Files.createDirectories(dir);
+            String filename = "chunk-" + chunk.getId() + "-" + System.currentTimeMillis() + ".json";
+            Path target = dir.resolve(filename);
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("timestamp", Instant.now().toString());
+            payload.put("projectKey", projectKey);
+            payload.put("repositorySlug", repoSlug);
+            payload.put("pullRequestId", prId);
+            payload.put("chunkId", chunk.getId());
+            payload.put("files", chunk.getFiles());
+            payload.put("model", model);
+            payload.put("truncated", truncated);
+            payload.put("systemPrompt", systemPrompt);
+            payload.put("userPrompt", userPrompt);
+            payload.put("overview", overview);
+            payload.put("annotatedDiff", annotatedDiff);
+
+            OBJECT_MAPPER.writeValue(new File(target.toString()), payload);
+        } catch (Exception ex) {
+            log.warn("Failed to write verbose prompt payload", ex);
         }
     }
 

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/OllamaAiReviewClient.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/OllamaAiReviewClient.java
@@ -615,9 +615,17 @@ public class OllamaAiReviewClient implements AiReviewClient {
             }
 
             if (maxFiles > 0) {
-                int excess = files.size() - maxFiles;
+                List<Path> remaining = Files.list(dir)
+                        .filter(Files::isRegularFile)
+                        .sorted((left, right) -> {
+                            long leftTime = lastModifiedMillis(left);
+                            long rightTime = lastModifiedMillis(right);
+                            return Long.compare(leftTime, rightTime);
+                        })
+                        .toList();
+                int excess = remaining.size() - maxFiles;
                 for (int i = 0; i < excess; i++) {
-                    Files.deleteIfExists(files.get(i));
+                    Files.deleteIfExists(remaining.get(i));
                 }
             }
         } catch (Exception ex) {

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/OllamaAiReviewClient.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/OllamaAiReviewClient.java
@@ -28,7 +28,6 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -64,6 +63,8 @@ public class OllamaAiReviewClient implements AiReviewClient {
             .configure(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature(), true);
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {};
     private static final Pattern LINE_MARKER_PATTERN = Pattern.compile("\\[Line\\s+(\\d+)]");
+    private static final int VERBOSE_MAX_FILES = Integer.getInteger("ai.reviewer.verbose.maxFiles", 200);
+    private static final long VERBOSE_MAX_AGE_DAYS = Long.getLong("ai.reviewer.verbose.maxAgeDays", 7L);
 
     private final CircuitBreaker circuitBreaker = new CircuitBreaker("ollama-client", 5, Duration.ofMinutes(1));
     private final RateLimiter rateLimiter = new RateLimiter("ollama-client", 10, Duration.ofSeconds(1));
@@ -576,9 +577,59 @@ public class OllamaAiReviewClient implements AiReviewClient {
             payload.put("overview", overview);
             payload.put("annotatedDiff", annotatedDiff);
 
-            OBJECT_MAPPER.writeValue(new File(target.toString()), payload);
+            OBJECT_MAPPER.writeValue(target.toFile(), payload);
+            pruneVerboseDir(dir);
         } catch (Exception ex) {
             log.warn("Failed to write verbose prompt payload", ex);
+        }
+    }
+
+    private void pruneVerboseDir(Path dir) {
+        if (dir == null || (!Files.exists(dir))) {
+            return;
+        }
+        int maxFiles = VERBOSE_MAX_FILES;
+        long maxAgeDays = VERBOSE_MAX_AGE_DAYS;
+        if (maxFiles <= 0 && maxAgeDays <= 0) {
+            return;
+        }
+        Instant cutoff = maxAgeDays > 0 ? Instant.now().minus(Duration.ofDays(maxAgeDays)) : null;
+        try {
+            List<Path> files = Files.list(dir)
+                    .filter(Files::isRegularFile)
+                    .sorted((left, right) -> {
+                        long leftTime = lastModifiedMillis(left);
+                        long rightTime = lastModifiedMillis(right);
+                        return Long.compare(leftTime, rightTime);
+                    })
+                    .toList();
+
+            for (Path file : files) {
+                if (cutoff == null) {
+                    break;
+                }
+                Instant modified = Instant.ofEpochMilli(lastModifiedMillis(file));
+                if (modified.isBefore(cutoff)) {
+                    Files.deleteIfExists(file);
+                }
+            }
+
+            if (maxFiles > 0) {
+                int excess = files.size() - maxFiles;
+                for (int i = 0; i < excess; i++) {
+                    Files.deleteIfExists(files.get(i));
+                }
+            }
+        } catch (Exception ex) {
+            log.debug("Failed to prune verbose prompt payloads", ex);
+        }
+    }
+
+    private long lastModifiedMillis(Path path) {
+        try {
+            return Files.getLastModifiedTime(path).toMillis();
+        } catch (Exception ex) {
+            return 0L;
         }
     }
 

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -170,6 +170,9 @@ public class ReviewConfigFactory {
                 continue;
             }
             String text = (String) value;
+            if (text.trim().isEmpty()) {
+                continue;
+            }
             switch (lower) {
                 case "prompt.system.append":
                     systemAppend = text;

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -72,6 +72,7 @@ public class ReviewConfigFactory {
 
         builder.profile(buildProfile(config));
         builder.promptTemplates(loadPromptTemplates(config));
+        builder.verboseMode(booleanValue(config.get("verboseMode"), false));
 
         return builder.build();
     }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -188,24 +188,26 @@ public class ReviewConfigFactory {
     private PromptTemplates applyPromptAppends(PromptTemplates base,
                                                String systemAppend,
                                                String chunkAppend) {
-        String updatedSystem = appendPrompt(base.getSystemPrompt(), systemAppend, true);
-        String updatedChunk = appendPrompt(base.getChunkInstructionsTemplate(), chunkAppend, true);
+        String updatedSystem = appendSystemPrompt(base.getSystemPrompt(), systemAppend);
+        String updatedChunk = appendChunkPrompt(base.getChunkInstructionsTemplate(), chunkAppend);
         if (updatedSystem.equals(base.getSystemPrompt()) && updatedChunk.equals(base.getChunkInstructionsTemplate())) {
             return base;
         }
-        return PromptTemplates.builder()
-                .systemPrompt(updatedSystem)
-                .chunkInstructionsTemplate(updatedChunk)
-                .overviewTemplate(base.getOverviewTemplate())
-                .overviewFileEntryTemplate(base.getOverviewFileEntryTemplate())
-                .build();
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("prompt.system", updatedSystem);
+        overrides.put("prompt.chunk", updatedChunk);
+        return base.withOverrides(overrides);
     }
 
-    private String appendPrompt(String base, String addition) {
-        return appendPrompt(base, addition, false);
+    private String appendSystemPrompt(String base, String addition) {
+        return appendPromptInternal(base, addition, true);
     }
 
-    private String appendPrompt(String base, String addition, boolean withHeader) {
+    private String appendChunkPrompt(String base, String addition) {
+        return appendPromptInternal(base, addition, true);
+    }
+
+    private String appendPromptInternal(String base, String addition, boolean withHeader) {
         String trimmedAddition = addition != null ? addition.trim() : "";
         boolean hasAddition = !trimmedAddition.isEmpty();
         if (!hasAddition && base.contains("{{ADDITIONAL_INSTRUCTIONS}}")) {

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -187,7 +187,7 @@ public class ReviewConfigFactory {
     private PromptTemplates applyPromptAppends(PromptTemplates base,
                                                String systemAppend,
                                                String chunkAppend) {
-        String updatedSystem = appendPrompt(base.getSystemPrompt(), systemAppend);
+        String updatedSystem = appendPrompt(base.getSystemPrompt(), systemAppend, true);
         String updatedChunk = appendPrompt(base.getChunkInstructionsTemplate(), chunkAppend);
         if (updatedSystem.equals(base.getSystemPrompt()) && updatedChunk.equals(base.getChunkInstructionsTemplate())) {
             return base;
@@ -201,10 +201,27 @@ public class ReviewConfigFactory {
     }
 
     private String appendPrompt(String base, String addition) {
-        if (addition == null || addition.trim().isEmpty()) {
+        return appendPrompt(base, addition, false);
+    }
+
+    private String appendPrompt(String base, String addition, boolean withHeader) {
+        String trimmedAddition = addition != null ? addition.trim() : "";
+        boolean hasAddition = !trimmedAddition.isEmpty();
+        if (!hasAddition && base.contains("{{ADDITIONAL_INSTRUCTIONS}}")) {
+            return base.replace("{{ADDITIONAL_INSTRUCTIONS}}", "").trim();
+        }
+        if (!hasAddition) {
             return base;
         }
+        if (base.contains("{{ADDITIONAL_INSTRUCTIONS}}")) {
+            String replacement = withHeader ? "ADDITIONAL INSTRUCTIONS:\n" + trimmedAddition : trimmedAddition;
+            return base.replace("{{ADDITIONAL_INSTRUCTIONS}}", replacement).trim();
+        }
         String separator = base.endsWith("\n") ? "" : "\n";
-        return base + separator + addition;
+        if (!withHeader) {
+            return base + separator + trimmedAddition;
+        }
+        String header = "ADDITIONAL INSTRUCTIONS:\n";
+        return base + separator + header + trimmedAddition;
     }
 }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -29,6 +29,8 @@ import java.util.stream.Collectors;
 public class ReviewConfigFactory {
 
     private static final Logger log = LoggerFactory.getLogger(ReviewConfigFactory.class);
+    private static final String ADDITIONAL_INSTRUCTIONS_PLACEHOLDER = "{{ADDITIONAL_INSTRUCTIONS}}";
+    private static final String ADDITIONAL_INSTRUCTIONS_HEADER = "ADDITIONAL INSTRUCTIONS:\n";
 
     @Nonnull
     public ReviewConfig from(@Nonnull Map<String, Object> config) {
@@ -191,8 +193,8 @@ public class ReviewConfigFactory {
     private PromptTemplates applyPromptAppends(PromptTemplates base,
                                                String systemAppend,
                                                String chunkAppend) {
-        String updatedSystem = appendSystemPrompt(base.getSystemPrompt(), systemAppend);
-        String updatedChunk = appendChunkPrompt(base.getChunkInstructionsTemplate(), chunkAppend);
+        String updatedSystem = appendWithAdditionalInstructions(base.getSystemPrompt(), systemAppend);
+        String updatedChunk = appendWithAdditionalInstructions(base.getChunkInstructionsTemplate(), chunkAppend);
         if (updatedSystem.equals(base.getSystemPrompt()) && updatedChunk.equals(base.getChunkInstructionsTemplate())) {
             return base;
         }
@@ -202,32 +204,24 @@ public class ReviewConfigFactory {
         return base.withOverrides(overrides);
     }
 
-    private String appendSystemPrompt(String base, String addition) {
-        return appendPromptInternal(base, addition, true);
-    }
-
-    private String appendChunkPrompt(String base, String addition) {
-        return appendPromptInternal(base, addition, true);
-    }
-
-    private String appendPromptInternal(String base, String addition, boolean withHeader) {
+    private String appendWithAdditionalInstructions(String base, String addition) {
         String trimmedAddition = addition != null ? addition.trim() : "";
         boolean hasAddition = !trimmedAddition.isEmpty();
-        if (!hasAddition && base.contains("{{ADDITIONAL_INSTRUCTIONS}}")) {
-            return base.replace("{{ADDITIONAL_INSTRUCTIONS}}", "").trim();
+        boolean hasPlaceholder = base.contains(ADDITIONAL_INSTRUCTIONS_PLACEHOLDER);
+
+        if (hasPlaceholder) {
+            if (!hasAddition) {
+                return base.replace(ADDITIONAL_INSTRUCTIONS_PLACEHOLDER, "").trim();
+            }
+            String replacement = ADDITIONAL_INSTRUCTIONS_HEADER + trimmedAddition;
+            return base.replace(ADDITIONAL_INSTRUCTIONS_PLACEHOLDER, replacement).trim();
         }
+
         if (!hasAddition) {
             return base;
         }
-        if (base.contains("{{ADDITIONAL_INSTRUCTIONS}}")) {
-            String replacement = withHeader ? "ADDITIONAL INSTRUCTIONS:\n" + trimmedAddition : trimmedAddition;
-            return base.replace("{{ADDITIONAL_INSTRUCTIONS}}", replacement).trim();
-        }
+
         String separator = base.endsWith("\n") ? "" : "\n";
-        if (!withHeader) {
-            return base + separator + trimmedAddition;
-        }
-        String header = "ADDITIONAL INSTRUCTIONS:\n";
-        return base + separator + header + trimmedAddition;
+        return base + separator + ADDITIONAL_INSTRUCTIONS_HEADER + trimmedAddition;
     }
 }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -153,21 +153,58 @@ public class ReviewConfigFactory {
     private PromptTemplates loadPromptTemplates(Map<String, Object> config) {
         PromptTemplates defaults = PromptTemplates.loadDefaults();
         Map<String, String> overrides = new HashMap<>();
-        config.forEach((key, value) -> {
+        String systemAppend = null;
+        String chunkAppend = null;
+        for (Map.Entry<String, Object> entry : config.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
             if (key == null || value == null) {
-                return;
+                continue;
             }
             String lower = key.toLowerCase();
             if (!lower.startsWith("prompt")) {
-                return;
+                continue;
             }
-            if (value instanceof String) {
-                overrides.put(lower, (String) value);
+            if (!(value instanceof String)) {
+                continue;
             }
-        });
-        if (overrides.isEmpty()) {
-            return defaults;
+            String text = (String) value;
+            switch (lower) {
+                case "prompt.system.append":
+                    systemAppend = text;
+                    break;
+                case "prompt.chunk.append":
+                    chunkAppend = text;
+                    break;
+                default:
+                    overrides.put(lower, text);
+            }
         }
-        return defaults.withOverrides(overrides);
+        PromptTemplates resolved = overrides.isEmpty() ? defaults : defaults.withOverrides(overrides);
+        return applyPromptAppends(resolved, systemAppend, chunkAppend);
+    }
+
+    private PromptTemplates applyPromptAppends(PromptTemplates base,
+                                               String systemAppend,
+                                               String chunkAppend) {
+        String updatedSystem = appendPrompt(base.getSystemPrompt(), systemAppend);
+        String updatedChunk = appendPrompt(base.getChunkInstructionsTemplate(), chunkAppend);
+        if (updatedSystem.equals(base.getSystemPrompt()) && updatedChunk.equals(base.getChunkInstructionsTemplate())) {
+            return base;
+        }
+        return PromptTemplates.builder()
+                .systemPrompt(updatedSystem)
+                .chunkInstructionsTemplate(updatedChunk)
+                .overviewTemplate(base.getOverviewTemplate())
+                .overviewFileEntryTemplate(base.getOverviewFileEntryTemplate())
+                .build();
+    }
+
+    private String appendPrompt(String base, String addition) {
+        if (addition == null || addition.trim().isEmpty()) {
+            return base;
+        }
+        String separator = base.endsWith("\n") ? "" : "\n";
+        return base + separator + addition;
     }
 }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactory.java
@@ -189,7 +189,7 @@ public class ReviewConfigFactory {
                                                String systemAppend,
                                                String chunkAppend) {
         String updatedSystem = appendPrompt(base.getSystemPrompt(), systemAppend, true);
-        String updatedChunk = appendPrompt(base.getChunkInstructionsTemplate(), chunkAppend);
+        String updatedChunk = appendPrompt(base.getChunkInstructionsTemplate(), chunkAppend, true);
         if (updatedSystem.equals(base.getSystemPrompt()) && updatedChunk.equals(base.getChunkInstructionsTemplate())) {
             return base;
         }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aicode/model/ReviewConfig.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aicode/model/ReviewConfig.java
@@ -33,6 +33,7 @@ public final class ReviewConfig {
     private final int maxDiffBytes;
     private final ReviewProfile profile;
     private final PromptTemplates promptTemplates;
+    private final boolean verboseMode;
 
     private ReviewConfig(Builder builder) {
         this.primaryModelEndpoint = builder.primaryModelEndpoint;
@@ -56,6 +57,7 @@ public final class ReviewConfig {
         this.maxDiffBytes = builder.maxDiffBytes;
         this.profile = builder.profile;
         this.promptTemplates = builder.promptTemplates;
+        this.verboseMode = builder.verboseMode;
     }
 
     @Nonnull
@@ -159,6 +161,10 @@ public final class ReviewConfig {
         return promptTemplates;
     }
 
+    public boolean isVerboseMode() {
+        return verboseMode;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -185,6 +191,7 @@ public final class ReviewConfig {
         private int maxDiffBytes = 10_000_000;
         private ReviewProfile profile = ReviewProfile.builder().build();
         private PromptTemplates promptTemplates = PromptTemplates.loadDefaults();
+    private boolean verboseMode = false;
 
         public Builder primaryModelEndpoint(@Nonnull URI uri) {
             this.primaryModelEndpoint = Objects.requireNonNull(uri, "uri");
@@ -253,6 +260,11 @@ public final class ReviewConfig {
 
         public Builder overviewRetryDelayMs(int value) {
             this.overviewRetryDelayMs = value;
+            return this;
+        }
+
+        public Builder verboseMode(boolean value) {
+            this.verboseMode = value;
             return this;
         }
 

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/ao/AIReviewConfiguration.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/ao/AIReviewConfiguration.java
@@ -153,6 +153,10 @@ public interface AIReviewConfiguration extends Entity {
     boolean isModelHealthEnabled();
     void setModelHealthEnabled(boolean enabled);
 
+    @Default("false")
+    boolean isVerboseMode();
+    void setVerboseMode(boolean enabled);
+
     // Review Profile Configuration
     @StringLength(50)
     String getMinSeverity();

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/ao/AIReviewConfiguration.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/ao/AIReviewConfiguration.java
@@ -206,6 +206,18 @@ public interface AIReviewConfiguration extends Entity {
     String getScopeMode();
     void setScopeMode(String scopeMode);
 
+    @StringLength(StringLength.UNLIMITED)
+    String getPromptSystemAppend();
+    void setPromptSystemAppend(String value);
+
+    @StringLength(StringLength.UNLIMITED)
+    String getPromptChunkOverride();
+    void setPromptChunkOverride(String value);
+
+    @StringLength(StringLength.UNLIMITED)
+    String getPromptChunkAppend();
+    void setPromptChunkAppend(String value);
+
     // Configuration Metadata
     @StringLength(100)
     String getConfigurationName();

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/ConfigResource.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/ConfigResource.java
@@ -10,6 +10,8 @@ import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.user.UserKey;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
+import com.teknolojikpanda.bitbucket.aicode.core.ReviewConfigFactory;
+import com.teknolojikpanda.bitbucket.aicode.model.PromptTemplates;
 import com.teknolojikpanda.bitbucket.aicode.model.ReviewProfilePreset;
 import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService;
 import com.teknolojikpanda.bitbucket.aireviewer.util.PromptKeySupport;
@@ -79,6 +81,7 @@ public class ConfigResource {
     private final UserManager userManager;
     private final UserService userService;
     private final AIReviewerConfigService configService;
+    private final ReviewConfigFactory configFactory;
     private final ReviewRateLimiter rateLimiter;
     private final GuardrailsRateLimitOverrideService overrideService;
     private final GuardrailsRateLimitStore rateLimitStore;
@@ -88,12 +91,14 @@ public class ConfigResource {
             @ComponentImport UserManager userManager,
             @ComponentImport UserService userService,
             AIReviewerConfigService configService,
+            ReviewConfigFactory configFactory,
             ReviewRateLimiter rateLimiter,
             GuardrailsRateLimitOverrideService overrideService,
             GuardrailsRateLimitStore rateLimitStore) {
         this.userManager = userManager;
         this.userService = userService;
         this.configService = configService;
+        this.configFactory = Objects.requireNonNull(configFactory, "configFactory");
         this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter");
         this.overrideService = Objects.requireNonNull(overrideService, "overrideService");
         this.rateLimitStore = Objects.requireNonNull(rateLimitStore, "rateLimitStore");
@@ -128,6 +133,7 @@ public class ConfigResource {
             config.put("limiter", limiterSnapshot());
             config.put("rateLimitOverrides", overridesToList(overrideService.listOverrides(false)));
             config.put("rateLimitIncidents", incidentsToList(rateLimitStore.fetchRecentIncidents(RECENT_LIMITER_INCIDENTS)));
+            config.put("promptEffective", buildPromptEffective(config));
             return Response.ok(config).build();
         } catch (Exception e) {
             log.error("Error getting configuration", e);
@@ -810,6 +816,17 @@ public class ConfigResource {
             error.put("details", details);
         }
         return error;
+    }
+
+    private Map<String, String> buildPromptEffective(Map<String, Object> config) {
+        if (config == null || config.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        PromptTemplates templates = configFactory.from(config).getPromptTemplates();
+        Map<String, String> effective = new LinkedHashMap<>();
+        effective.put("prompt.system", templates.getSystemPrompt());
+        effective.put("prompt.chunk", templates.getChunkInstructionsTemplate());
+        return effective;
     }
 
     /**

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/ConfigResource.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/ConfigResource.java
@@ -12,6 +12,7 @@ import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.teknolojikpanda.bitbucket.aicode.model.ReviewProfilePreset;
 import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService;
+import com.teknolojikpanda.bitbucket.aireviewer.util.PromptKeySupport;
 import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService.ScopeMode;
 import com.teknolojikpanda.bitbucket.aireviewer.service.ConfigurationValidationException;
 import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService.RepositoryCatalogPage;
@@ -840,18 +841,11 @@ public class ConfigResource {
             if ("scopeMode".equals(key)) {
                 return;
             }
-            if (allowedKeys.contains(key) || isPromptKey(key)) {
+            if (allowedKeys.contains(key) || PromptKeySupport.isPromptKey(key)) {
                 normalized.put(key, value);
             }
         });
         return normalized;
-    }
-
-    private boolean isPromptKey(String key) {
-        if (key == null) {
-            return false;
-        }
-        return key.toLowerCase(Locale.ROOT).startsWith("prompt");
     }
 
     private String stringValue(Object value) {

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/ConfigResource.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/ConfigResource.java
@@ -840,11 +840,18 @@ public class ConfigResource {
             if ("scopeMode".equals(key)) {
                 return;
             }
-            if (allowedKeys.contains(key)) {
+            if (allowedKeys.contains(key) || isPromptKey(key)) {
                 normalized.put(key, value);
             }
         });
         return normalized;
+    }
+
+    private boolean isPromptKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        return key.toLowerCase(Locale.ROOT).startsWith("prompt");
     }
 
     private String stringValue(Object value) {

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/RepoConfigResource.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/rest/RepoConfigResource.java
@@ -9,6 +9,8 @@ import com.atlassian.bitbucket.user.UserService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
+import com.teknolojikpanda.bitbucket.aicode.core.ReviewConfigFactory;
+import com.teknolojikpanda.bitbucket.aicode.model.PromptTemplates;
 import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService;
 
 import javax.inject.Inject;
@@ -37,18 +39,21 @@ public class RepoConfigResource {
     private final PermissionService permissionService;
     private final UserService userService;
     private final AIReviewerConfigService configService;
+    private final ReviewConfigFactory configFactory;
 
     @Inject
     public RepoConfigResource(@ComponentImport UserManager userManager,
                               @ComponentImport RepositoryService repositoryService,
                               @ComponentImport PermissionService permissionService,
                               @ComponentImport UserService userService,
-                              AIReviewerConfigService configService) {
+                              AIReviewerConfigService configService,
+                              ReviewConfigFactory configFactory) {
         this.userManager = Objects.requireNonNull(userManager, "userManager");
         this.repositoryService = Objects.requireNonNull(repositoryService, "repositoryService");
         this.permissionService = Objects.requireNonNull(permissionService, "permissionService");
         this.userService = Objects.requireNonNull(userService, "userService");
         this.configService = Objects.requireNonNull(configService, "configService");
+        this.configFactory = Objects.requireNonNull(configFactory, "configFactory");
     }
 
     @GET
@@ -63,6 +68,7 @@ public class RepoConfigResource {
         }
 
         Map<String, Object> payload = configService.getRepositoryConfiguration(projectKey, repositorySlug);
+        payload.put("promptEffective", buildPromptEffective(payload));
         return Response.ok(payload).build();
     }
 
@@ -107,6 +113,7 @@ public class RepoConfigResource {
                 context.user != null ? context.user.getSlug() : null);
 
         Map<String, Object> payload = configService.getRepositoryConfiguration(projectKey, repositorySlug);
+        payload.put("promptEffective", buildPromptEffective(payload));
         return Response.ok(payload).build();
     }
 
@@ -142,6 +149,7 @@ public class RepoConfigResource {
 
         configService.clearRepositoryConfiguration(projectKey, repositorySlug);
         Map<String, Object> payload = configService.getRepositoryConfiguration(projectKey, repositorySlug);
+        payload.put("promptEffective", buildPromptEffective(payload));
         return Response.ok(payload).build();
     }
 
@@ -198,6 +206,23 @@ public class RepoConfigResource {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("error", message);
         return map;
+    }
+
+    private Map<String, String> buildPromptEffective(Map<String, Object> payload) {
+        if (payload == null || payload.isEmpty()) {
+            return Map.of();
+        }
+        Object effective = payload.get("effective");
+        if (!(effective instanceof Map)) {
+            return Map.of();
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> effectiveConfig = (Map<String, Object>) effective;
+        PromptTemplates templates = configFactory.from(effectiveConfig).getPromptTemplates();
+        Map<String, String> promptEffective = new LinkedHashMap<>();
+        promptEffective.put("prompt.system", templates.getSystemPrompt());
+        promptEffective.put("prompt.chunk", templates.getChunkInstructionsTemplate());
+        return promptEffective;
     }
 
     private static final class AccessContext {

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/service/AIReviewerConfigServiceImpl.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/service/AIReviewerConfigServiceImpl.java
@@ -18,6 +18,7 @@ import com.teknolojikpanda.bitbucket.aicode.model.ReviewProfilePreset;
 import com.teknolojikpanda.bitbucket.aireviewer.ao.AIReviewConfiguration;
 import com.teknolojikpanda.bitbucket.aireviewer.ao.AIReviewRepoConfiguration;
 import com.teknolojikpanda.bitbucket.aireviewer.util.HttpClientUtil;
+import com.teknolojikpanda.bitbucket.aireviewer.util.PromptKeySupport;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -310,13 +311,13 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
 
         Map<String, String> errors = new LinkedHashMap<>();
 
-    configMap.keySet().stream()
-        .filter(Objects::nonNull)
-        .map(Object::toString)
-        .filter(key -> !SUPPORTED_KEYS.contains(key)
-            && !DERIVED_KEYS.contains(key)
-            && !isPromptKey(key))
-        .forEach(key -> errors.putIfAbsent(key, "Unsupported configuration key '" + key + "'"));
+        configMap.keySet().stream()
+            .filter(Objects::nonNull)
+            .map(Object::toString)
+            .filter(key -> !SUPPORTED_KEYS.contains(key)
+                && !DERIVED_KEYS.contains(key)
+                && !PromptKeySupport.isPromptKey(key))
+            .forEach(key -> errors.putIfAbsent(key, "Unsupported configuration key '" + key + "'"));
 
         validateString(configMap, "ollamaUrl", true, 2048, errors, value -> {
             try {
@@ -1042,7 +1043,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
                 return;
             }
             String trimmedKey = key.trim();
-            if (trimmedKey.isEmpty() || (!SUPPORTED_KEYS.contains(trimmedKey) && !isPromptKey(trimmedKey))) {
+            if (trimmedKey.isEmpty() || (!SUPPORTED_KEYS.contains(trimmedKey) && !PromptKeySupport.isPromptKey(trimmedKey))) {
                 return;
             }
             Object normalizedValue = normalizeOverrideValue(trimmedKey, value);
@@ -1057,7 +1058,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         if (value == null) {
             return null;
         }
-        if (isPromptKey(key)) {
+        if (PromptKeySupport.isPromptKey(key)) {
             if (!(value instanceof String)) {
                 value = String.valueOf(value);
             }
@@ -2085,10 +2086,5 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         return raw.trim().isEmpty() ? null : raw;
     }
 
-    private boolean isPromptKey(String key) {
-        if (key == null) {
-            return false;
-        }
-        return key.trim().toLowerCase(Locale.ROOT).startsWith("prompt");
-    }
+
 }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/service/AIReviewerConfigServiceImpl.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/service/AIReviewerConfigServiceImpl.java
@@ -108,7 +108,8 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
             "skipGeneratedFiles",
             "skipTests",
             "autoApprove",
-            "workerDegradationEnabled"
+        "workerDegradationEnabled",
+        "verboseMode"
     )));
 
     private static final Set<String> SUPPORTED_KEYS;
@@ -159,6 +160,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
     private static final boolean DEFAULT_SKIP_TESTS = false;
     private static final boolean DEFAULT_AUTO_APPROVE = false;
     private static final boolean DEFAULT_WORKER_DEGRADATION_ENABLED = true;
+    private static final boolean DEFAULT_VERBOSE_MODE = false;
     private static final String DEFAULT_PRIORITY_PROJECTS = "";
     private static final String DEFAULT_PRIORITY_REPOSITORIES = "";
     private static final int DEFAULT_REPO_ALERT_PERCENT = 80;
@@ -219,6 +221,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
                 "skipTests",
                 "autoApprove",
                 "workerDegradationEnabled",
+                "verboseMode",
                 "aiReviewerUser",
                 "scopeMode"
         ));
@@ -529,6 +532,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         defaults.put("skipTests", DEFAULT_SKIP_TESTS);
         defaults.put("autoApprove", DEFAULT_AUTO_APPROVE);
         defaults.put("workerDegradationEnabled", DEFAULT_WORKER_DEGRADATION_ENABLED);
+    defaults.put("verboseMode", DEFAULT_VERBOSE_MODE);
         defaults.put("aiReviewerUser", null);
         defaults.put("priorityProjects", DEFAULT_PRIORITY_PROJECTS);
         defaults.put("priorityRepositories", DEFAULT_PRIORITY_REPOSITORIES);
@@ -1215,6 +1219,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         config.setSkipTests(DEFAULT_SKIP_TESTS);
         config.setAutoApprove(DEFAULT_AUTO_APPROVE);
         config.setWorkerDegradationEnabled(DEFAULT_WORKER_DEGRADATION_ENABLED);
+    config.setVerboseMode(DEFAULT_VERBOSE_MODE);
         config.setReviewerUserSlug(null);
     config.setPromptSystemAppend(null);
     config.setPromptChunkOverride(null);
@@ -1384,6 +1389,9 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         }
         if (configMap.containsKey("workerDegradationEnabled")) {
             config.setWorkerDegradationEnabled(getBooleanValue(configMap, "workerDegradationEnabled"));
+        }
+        if (configMap.containsKey("verboseMode")) {
+            config.setVerboseMode(getBooleanValue(configMap, "verboseMode"));
         }
         if (configMap.containsKey("aiReviewerUser")) {
             config.setReviewerUserSlug(trimToNull(configMap.get("aiReviewerUser")));
@@ -1807,6 +1815,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         map.put("skipTests", defaultBoolean(config.isSkipTests(), DEFAULT_SKIP_TESTS));
         map.put("autoApprove", defaultBoolean(config.isAutoApprove(), DEFAULT_AUTO_APPROVE));
         map.put("workerDegradationEnabled", defaultBoolean(config.isWorkerDegradationEnabled(), DEFAULT_WORKER_DEGRADATION_ENABLED));
+    map.put("verboseMode", defaultBoolean(config.isVerboseMode(), DEFAULT_VERBOSE_MODE));
         map.put("aiReviewerUser", trimToNull(config.getReviewerUserSlug()));
         map.put("aiReviewerUserDisplayName", resolveUserDisplayName(config.getReviewerUserSlug()));
         map.put("scopeMode", defaultString(config.getScopeMode(), DEFAULT_SCOPE_MODE));

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/service/AIReviewerConfigServiceImpl.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/service/AIReviewerConfigServiceImpl.java
@@ -307,11 +307,13 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
 
         Map<String, String> errors = new LinkedHashMap<>();
 
-        configMap.keySet().stream()
-                .filter(Objects::nonNull)
-                .map(Object::toString)
-                .filter(key -> !SUPPORTED_KEYS.contains(key) && !DERIVED_KEYS.contains(key))
-                .forEach(key -> errors.putIfAbsent(key, "Unsupported configuration key '" + key + "'"));
+    configMap.keySet().stream()
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .filter(key -> !SUPPORTED_KEYS.contains(key)
+            && !DERIVED_KEYS.contains(key)
+            && !isPromptKey(key))
+        .forEach(key -> errors.putIfAbsent(key, "Unsupported configuration key '" + key + "'"));
 
         validateString(configMap, "ollamaUrl", true, 2048, errors, value -> {
             try {
@@ -397,8 +399,8 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
                 errors.put(key, "Prompt values must be strings");
                 return;
             }
-            String text = ((String) value).trim();
-            if (text.isEmpty()) {
+            String text = (String) value;
+            if (text.trim().isEmpty()) {
                 errors.put(key, "Prompt overrides cannot be empty");
             } else if (text.length() > 10_000) {
                 errors.put(key, "Prompt overrides must be 10,000 characters or fewer");
@@ -1036,7 +1038,7 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
                 return;
             }
             String trimmedKey = key.trim();
-            if (trimmedKey.isEmpty() || !SUPPORTED_KEYS.contains(trimmedKey)) {
+            if (trimmedKey.isEmpty() || (!SUPPORTED_KEYS.contains(trimmedKey) && !isPromptKey(trimmedKey))) {
                 return;
             }
             Object normalizedValue = normalizeOverrideValue(trimmedKey, value);
@@ -1050,6 +1052,13 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
     private Object normalizeOverrideValue(String key, Object value) {
         if (value == null) {
             return null;
+        }
+        if (isPromptKey(key)) {
+            if (!(value instanceof String)) {
+                value = String.valueOf(value);
+            }
+            String raw = (String) value;
+            return raw.trim().isEmpty() ? null : raw;
         }
         if (INTEGER_KEYS.contains(key)) {
             return parseInteger(value);
@@ -1207,6 +1216,9 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         config.setAutoApprove(DEFAULT_AUTO_APPROVE);
         config.setWorkerDegradationEnabled(DEFAULT_WORKER_DEGRADATION_ENABLED);
         config.setReviewerUserSlug(null);
+    config.setPromptSystemAppend(null);
+    config.setPromptChunkOverride(null);
+    config.setPromptChunkAppend(null);
         config.setGlobalDefault(true);
         long now = System.currentTimeMillis();
         config.setCreatedDate(now);
@@ -1379,6 +1391,15 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         if (configMap.containsKey("scopeMode")) {
             ScopeMode mode = ScopeMode.fromString(String.valueOf(configMap.get("scopeMode")));
             config.setScopeMode(mode.toConfigValue());
+        }
+        if (configMap.containsKey("prompt.system.append")) {
+            config.setPromptSystemAppend(promptValue(configMap.get("prompt.system.append")));
+        }
+        if (configMap.containsKey("prompt.chunk")) {
+            config.setPromptChunkOverride(promptValue(configMap.get("prompt.chunk")));
+        }
+        if (configMap.containsKey("prompt.chunk.append")) {
+            config.setPromptChunkAppend(promptValue(configMap.get("prompt.chunk.append")));
         }
     }
 
@@ -1789,6 +1810,9 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         map.put("aiReviewerUser", trimToNull(config.getReviewerUserSlug()));
         map.put("aiReviewerUserDisplayName", resolveUserDisplayName(config.getReviewerUserSlug()));
         map.put("scopeMode", defaultString(config.getScopeMode(), DEFAULT_SCOPE_MODE));
+        map.put("prompt.system.append", config.getPromptSystemAppend());
+        map.put("prompt.chunk", config.getPromptChunkOverride());
+        map.put("prompt.chunk.append", config.getPromptChunkAppend());
         return map;
     }
 
@@ -2042,5 +2066,20 @@ public class AIReviewerConfigServiceImpl implements AIReviewerConfigService {
         }
         String trimmed = ((String) value).trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String promptValue(Object value) {
+        if (!(value instanceof String)) {
+            return null;
+        }
+        String raw = (String) value;
+        return raw.trim().isEmpty() ? null : raw;
+    }
+
+    private boolean isPromptKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        return key.trim().toLowerCase(Locale.ROOT).startsWith("prompt");
     }
 }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminConfigServlet.java
@@ -126,6 +126,7 @@ public class AdminConfigServlet extends HttpServlet {
         context.put("skipTests", configValues.get("skipTests"));
         context.put("autoApprove", configValues.get("autoApprove"));
         context.put("workerDegradationEnabled", configValues.getOrDefault("workerDegradationEnabled", defaults.get("workerDegradationEnabled")));
+    context.put("verboseMode", configValues.getOrDefault("verboseMode", defaults.get("verboseMode")));
         context.put("aiReviewerUser", configValues.get("aiReviewerUser"));
     context.put("aiReviewerUserDisplayName", configValues.get("aiReviewerUserDisplayName"));
         templateRenderer.render("/templates/admin-config.vm", context, resp.getWriter());

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminConfigServlet.java
@@ -2,6 +2,7 @@ package com.teknolojikpanda.bitbucket.aireviewer.servlet;
 
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.atlassian.sal.api.user.UserKey;
@@ -36,17 +37,20 @@ public class AdminConfigServlet extends HttpServlet {
     private final LoginUriProvider loginUriProvider;
     private final TemplateRenderer templateRenderer;
     private final AIReviewerConfigService configService;
+    private final ApplicationPropertiesService applicationPropertiesService;
 
     @Inject
     public AdminConfigServlet(
             @ComponentImport UserManager userManager,
             @ComponentImport LoginUriProvider loginUriProvider,
             @ComponentImport TemplateRenderer templateRenderer,
-            AIReviewerConfigService configService) {
+            AIReviewerConfigService configService,
+            @ComponentImport ApplicationPropertiesService applicationPropertiesService) {
         this.userManager = Objects.requireNonNull(userManager, "userManager");
         this.loginUriProvider = Objects.requireNonNull(loginUriProvider, "loginUriProvider");
         this.templateRenderer = Objects.requireNonNull(templateRenderer, "templateRenderer");
         this.configService = Objects.requireNonNull(configService, "configService");
+        this.applicationPropertiesService = Objects.requireNonNull(applicationPropertiesService, "applicationPropertiesService");
     }
 
     @Override
@@ -147,6 +151,10 @@ public class AdminConfigServlet extends HttpServlet {
     }
 
     private String getBaseUrl(HttpServletRequest req) {
+        java.net.URI baseUrl = applicationPropertiesService.getBaseUrl();
+        if (baseUrl != null && !baseUrl.toString().trim().isEmpty()) {
+            return baseUrl.toString();
+        }
         return req.getScheme() + "://" + req.getServerName() +
                ":" + req.getServerPort() + req.getContextPath();
     }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminConfigServlet.java
@@ -127,7 +127,7 @@ public class AdminConfigServlet extends HttpServlet {
         context.put("autoApprove", configValues.get("autoApprove"));
         context.put("workerDegradationEnabled", configValues.getOrDefault("workerDegradationEnabled", defaults.get("workerDegradationEnabled")));
         context.put("aiReviewerUser", configValues.get("aiReviewerUser"));
-        context.put("aiReviewerUserDisplayName", configValues.get("aiReviewerUserDisplayName"));
+    context.put("aiReviewerUserDisplayName", configValues.get("aiReviewerUserDisplayName"));
         templateRenderer.render("/templates/admin-config.vm", context, resp.getWriter());
     }
 

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminPromptConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminPromptConfigServlet.java
@@ -2,6 +2,7 @@ package com.teknolojikpanda.bitbucket.aireviewer.servlet;
 
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.atlassian.sal.api.user.UserKey;
@@ -35,18 +36,21 @@ public class AdminPromptConfigServlet extends HttpServlet {
     private final TemplateRenderer templateRenderer;
     private final AIReviewerConfigService configService;
     private final ReviewConfigFactory configFactory;
+    private final ApplicationPropertiesService applicationPropertiesService;
 
     @Inject
     public AdminPromptConfigServlet(@ComponentImport UserManager userManager,
                                     @ComponentImport LoginUriProvider loginUriProvider,
                                     @ComponentImport TemplateRenderer templateRenderer,
                                     AIReviewerConfigService configService,
-                                    ReviewConfigFactory configFactory) {
+                                    ReviewConfigFactory configFactory,
+                                    @ComponentImport ApplicationPropertiesService applicationPropertiesService) {
         this.userManager = Objects.requireNonNull(userManager, "userManager");
         this.loginUriProvider = Objects.requireNonNull(loginUriProvider, "loginUriProvider");
         this.templateRenderer = Objects.requireNonNull(templateRenderer, "templateRenderer");
         this.configService = Objects.requireNonNull(configService, "configService");
         this.configFactory = Objects.requireNonNull(configFactory, "configFactory");
+        this.applicationPropertiesService = Objects.requireNonNull(applicationPropertiesService, "applicationPropertiesService");
     }
 
     @Override
@@ -117,6 +121,10 @@ public class AdminPromptConfigServlet extends HttpServlet {
     }
 
     private String getBaseUrl(HttpServletRequest req) {
+        java.net.URI baseUrl = applicationPropertiesService.getBaseUrl();
+        if (baseUrl != null && !baseUrl.toString().trim().isEmpty()) {
+            return baseUrl.toString();
+        }
         return req.getScheme() + "://" + req.getServerName() +
                ":" + req.getServerPort() + req.getContextPath();
     }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminPromptConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/AdminPromptConfigServlet.java
@@ -1,0 +1,123 @@
+package com.teknolojikpanda.bitbucket.aireviewer.servlet;
+
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+import com.atlassian.sal.api.user.UserKey;
+import com.atlassian.templaterenderer.TemplateRenderer;
+import com.teknolojikpanda.bitbucket.aicode.core.ReviewConfigFactory;
+import com.teknolojikpanda.bitbucket.aicode.model.PromptTemplates;
+import com.teknolojikpanda.bitbucket.aicode.model.ReviewConfig;
+import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Named
+public class AdminPromptConfigServlet extends HttpServlet {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminPromptConfigServlet.class);
+
+    private final UserManager userManager;
+    private final LoginUriProvider loginUriProvider;
+    private final TemplateRenderer templateRenderer;
+    private final AIReviewerConfigService configService;
+    private final ReviewConfigFactory configFactory;
+
+    @Inject
+    public AdminPromptConfigServlet(@ComponentImport UserManager userManager,
+                                    @ComponentImport LoginUriProvider loginUriProvider,
+                                    @ComponentImport TemplateRenderer templateRenderer,
+                                    AIReviewerConfigService configService,
+                                    ReviewConfigFactory configFactory) {
+        this.userManager = Objects.requireNonNull(userManager, "userManager");
+        this.loginUriProvider = Objects.requireNonNull(loginUriProvider, "loginUriProvider");
+        this.templateRenderer = Objects.requireNonNull(templateRenderer, "templateRenderer");
+        this.configService = Objects.requireNonNull(configService, "configService");
+        this.configFactory = Objects.requireNonNull(configFactory, "configFactory");
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        UserProfile profile = userManager.getRemoteUser(req);
+        if (profile == null) {
+            redirectToLogin(req, resp);
+            return;
+        }
+
+        UserKey userKey = profile.getUserKey();
+        if (userKey == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+                    "Unable to determine current user. Please authenticate again.");
+            return;
+        }
+
+        if (!userManager.isSystemAdmin(userKey)) {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN,
+                    "You must be an administrator to access this page");
+            return;
+        }
+
+        log.debug("Admin prompt config page accessed by: {}", profile.getUsername());
+
+        resp.setContentType("text/html;charset=UTF-8");
+        Map<String, Object> context = new HashMap<>();
+        context.put("username", profile.getUsername());
+        context.put("baseUrl", getBaseUrl(req));
+
+        Map<String, Object> defaults = new HashMap<>(configService.getDefaultConfiguration());
+        Map<String, Object> configValues = new HashMap<>(defaults);
+
+        try {
+            configValues.putAll(configService.getConfigurationAsMap());
+        } catch (Exception e) {
+            log.error("Failed to load configuration for prompt UI", e);
+            context.put("errorMessage", "Failed to load configuration: " + e.getMessage());
+        }
+
+        PromptTemplates promptDefaults = PromptTemplates.loadDefaults();
+        context.put("promptSystemDefault", promptDefaults.getSystemPrompt());
+        context.put("promptChunkDefault", promptDefaults.getChunkInstructionsTemplate());
+        context.put("promptChunkOverride", configValues.get("prompt.chunk"));
+        context.put("promptSystemAppend", configValues.get("prompt.system.append"));
+
+        ReviewConfig reviewConfig = configFactory.from(configValues);
+        PromptTemplates effectiveTemplates = reviewConfig.getPromptTemplates();
+        context.put("promptSystemEffective", effectiveTemplates.getSystemPrompt());
+        context.put("promptChunkEffective", effectiveTemplates.getChunkInstructionsTemplate());
+
+        templateRenderer.render("/templates/admin-prompts.vm", context, resp.getWriter());
+    }
+
+    private void redirectToLogin(HttpServletRequest req, HttpServletResponse resp)
+            throws IOException {
+        URI loginUri = loginUriProvider.getLoginUri(getUri(req));
+        resp.sendRedirect(loginUri.toASCIIString());
+    }
+
+    private URI getUri(HttpServletRequest req) {
+        StringBuffer builder = req.getRequestURL();
+        if (req.getQueryString() != null) {
+            builder.append("?").append(req.getQueryString());
+        }
+        return URI.create(builder.toString());
+    }
+
+    private String getBaseUrl(HttpServletRequest req) {
+        return req.getScheme() + "://" + req.getServerName() +
+               ":" + req.getServerPort() + req.getContextPath();
+    }
+}

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/RepoPromptConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/RepoPromptConfigServlet.java
@@ -1,0 +1,129 @@
+package com.teknolojikpanda.bitbucket.aireviewer.servlet;
+
+import com.atlassian.bitbucket.permission.Permission;
+import com.atlassian.bitbucket.permission.PermissionService;
+import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.repository.RepositoryService;
+import com.atlassian.bitbucket.user.ApplicationUser;
+import com.atlassian.bitbucket.user.UserService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+import com.atlassian.sal.api.user.UserKey;
+import com.atlassian.templaterenderer.TemplateRenderer;
+import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Named
+public class RepoPromptConfigServlet extends HttpServlet {
+
+    private final UserManager userManager;
+    private final LoginUriProvider loginUriProvider;
+    private final TemplateRenderer templateRenderer;
+    private final RepositoryService repositoryService;
+    private final PermissionService permissionService;
+    private final UserService userService;
+    private final AIReviewerConfigService configService;
+
+    @Inject
+    public RepoPromptConfigServlet(@ComponentImport UserManager userManager,
+                                   @ComponentImport LoginUriProvider loginUriProvider,
+                                   @ComponentImport TemplateRenderer templateRenderer,
+                                   @ComponentImport RepositoryService repositoryService,
+                                   @ComponentImport PermissionService permissionService,
+                                   @ComponentImport UserService userService,
+                                   AIReviewerConfigService configService) {
+        this.userManager = Objects.requireNonNull(userManager, "userManager");
+        this.loginUriProvider = Objects.requireNonNull(loginUriProvider, "loginUriProvider");
+        this.templateRenderer = Objects.requireNonNull(templateRenderer, "templateRenderer");
+        this.repositoryService = Objects.requireNonNull(repositoryService, "repositoryService");
+        this.permissionService = Objects.requireNonNull(permissionService, "permissionService");
+        this.userService = Objects.requireNonNull(userService, "userService");
+        this.configService = Objects.requireNonNull(configService, "configService");
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserProfile profile = userManager.getRemoteUser(req);
+        if (profile == null) {
+            redirectToLogin(req, resp);
+            return;
+        }
+
+        UserKey userKey = profile.getUserKey();
+        if (userKey == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+                    "Unable to determine current user. Please authenticate again.");
+            return;
+        }
+
+        String projectKey = req.getParameter("projectKey");
+        String repositorySlug = req.getParameter("repositorySlug");
+        if (projectKey == null || repositorySlug == null) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing repository context");
+            return;
+        }
+
+        Repository repository = repositoryService.getBySlug(projectKey, repositorySlug);
+        if (repository == null) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Repository not found");
+            return;
+        }
+
+        ApplicationUser user = userService.getUserBySlug(profile.getUsername());
+        if (user == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unable to resolve current user");
+            return;
+        }
+
+        boolean hasRepoAdmin = permissionService.hasRepositoryPermission(user, repository, Permission.REPO_ADMIN);
+        boolean hasProjectAdmin = permissionService.hasProjectPermission(user, repository.getProject(), Permission.PROJECT_ADMIN);
+        boolean hasGlobalAdmin = permissionService.hasGlobalPermission(user, Permission.ADMIN);
+        if (!hasRepoAdmin && !hasProjectAdmin && !hasGlobalAdmin) {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN,
+                    "You must be a repository or project admin to access this page");
+            return;
+        }
+
+        resp.setContentType("text/html;charset=UTF-8");
+        Map<String, Object> context = new HashMap<>();
+        context.put("baseUrl", getBaseUrl(req));
+        context.put("projectKey", repository.getProject().getKey());
+        context.put("projectName", repository.getProject().getName());
+        context.put("repositorySlug", repository.getSlug());
+        context.put("repositoryName", repository.getName());
+        context.put("username", profile.getUsername());
+        context.put("configServiceAvailable", configService != null);
+        templateRenderer.render("/templates/repo-config.vm", context, resp.getWriter());
+    }
+
+    private void redirectToLogin(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        URI loginUri = loginUriProvider.getLoginUri(getUri(req));
+        resp.sendRedirect(loginUri.toASCIIString());
+    }
+
+    private URI getUri(HttpServletRequest req) {
+        StringBuffer builder = req.getRequestURL();
+        if (req.getQueryString() != null) {
+            builder.append("?").append(req.getQueryString());
+        }
+        return URI.create(builder.toString());
+    }
+
+    private String getBaseUrl(HttpServletRequest req) {
+        return req.getScheme() + "://" + req.getServerName() +
+               ":" + req.getServerPort() + req.getContextPath();
+    }
+}

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/RepoPromptConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/RepoPromptConfigServlet.java
@@ -8,6 +8,7 @@ import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.bitbucket.user.UserService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.atlassian.sal.api.user.UserKey;
@@ -37,6 +38,7 @@ public class RepoPromptConfigServlet extends HttpServlet {
     private final PermissionService permissionService;
     private final UserService userService;
     private final AIReviewerConfigService configService;
+    private final ApplicationPropertiesService applicationPropertiesService;
 
     @Inject
     public RepoPromptConfigServlet(@ComponentImport UserManager userManager,
@@ -45,7 +47,8 @@ public class RepoPromptConfigServlet extends HttpServlet {
                                    @ComponentImport RepositoryService repositoryService,
                                    @ComponentImport PermissionService permissionService,
                                    @ComponentImport UserService userService,
-                                   AIReviewerConfigService configService) {
+                                   AIReviewerConfigService configService,
+                                   @ComponentImport ApplicationPropertiesService applicationPropertiesService) {
         this.userManager = Objects.requireNonNull(userManager, "userManager");
         this.loginUriProvider = Objects.requireNonNull(loginUriProvider, "loginUriProvider");
         this.templateRenderer = Objects.requireNonNull(templateRenderer, "templateRenderer");
@@ -53,6 +56,7 @@ public class RepoPromptConfigServlet extends HttpServlet {
         this.permissionService = Objects.requireNonNull(permissionService, "permissionService");
         this.userService = Objects.requireNonNull(userService, "userService");
         this.configService = Objects.requireNonNull(configService, "configService");
+        this.applicationPropertiesService = Objects.requireNonNull(applicationPropertiesService, "applicationPropertiesService");
     }
 
     @Override
@@ -130,6 +134,10 @@ public class RepoPromptConfigServlet extends HttpServlet {
     }
 
     private String getBaseUrl(HttpServletRequest req) {
+        java.net.URI baseUrl = applicationPropertiesService.getBaseUrl();
+        if (baseUrl != null && !baseUrl.toString().trim().isEmpty()) {
+            return baseUrl.toString();
+        }
         return req.getScheme() + "://" + req.getServerName() +
                ":" + req.getServerPort() + req.getContextPath();
     }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/RepoPromptConfigServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/RepoPromptConfigServlet.java
@@ -12,6 +12,7 @@ import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.atlassian.sal.api.user.UserKey;
 import com.atlassian.templaterenderer.TemplateRenderer;
+import com.teknolojikpanda.bitbucket.aicode.model.PromptTemplates;
 import com.teknolojikpanda.bitbucket.aireviewer.service.AIReviewerConfigService;
 
 import javax.inject.Inject;
@@ -82,6 +83,9 @@ public class RepoPromptConfigServlet extends HttpServlet {
             return;
         }
 
+        req.setAttribute("repository", repository);
+        req.setAttribute("project", repository.getProject());
+
         ApplicationUser user = userService.getUserBySlug(profile.getUsername());
         if (user == null) {
             resp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unable to resolve current user");
@@ -104,8 +108,11 @@ public class RepoPromptConfigServlet extends HttpServlet {
         context.put("projectName", repository.getProject().getName());
         context.put("repositorySlug", repository.getSlug());
         context.put("repositoryName", repository.getName());
+    context.put("repositoryId", repository.getId());
         context.put("username", profile.getUsername());
         context.put("configServiceAvailable", configService != null);
+    PromptTemplates promptDefaults = PromptTemplates.loadDefaults();
+    context.put("promptChunkDefault", promptDefaults.getChunkInstructionsTemplate());
         templateRenderer.render("/templates/repo-config.vm", context, resp.getWriter());
     }
 

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/ReviewHistoryServlet.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/servlet/ReviewHistoryServlet.java
@@ -2,6 +2,7 @@ package com.teknolojikpanda.bitbucket.aireviewer.servlet;
 
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import com.atlassian.sal.api.user.UserKey;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
@@ -32,14 +33,17 @@ public class ReviewHistoryServlet extends HttpServlet {
     private final UserManager userManager;
     private final LoginUriProvider loginUriProvider;
     private final TemplateRenderer templateRenderer;
+    private final ApplicationPropertiesService applicationPropertiesService;
 
     @Inject
     public ReviewHistoryServlet(@ComponentImport UserManager userManager,
                                 @ComponentImport LoginUriProvider loginUriProvider,
-                                @ComponentImport TemplateRenderer templateRenderer) {
+                                @ComponentImport TemplateRenderer templateRenderer,
+                                @ComponentImport ApplicationPropertiesService applicationPropertiesService) {
         this.userManager = Objects.requireNonNull(userManager, "userManager");
         this.loginUriProvider = Objects.requireNonNull(loginUriProvider, "loginUriProvider");
         this.templateRenderer = Objects.requireNonNull(templateRenderer, "templateRenderer");
+        this.applicationPropertiesService = Objects.requireNonNull(applicationPropertiesService, "applicationPropertiesService");
     }
 
     @Override
@@ -81,6 +85,10 @@ public class ReviewHistoryServlet extends HttpServlet {
     }
 
     private String getBaseUrl(HttpServletRequest req) {
+        java.net.URI baseUrl = applicationPropertiesService.getBaseUrl();
+        if (baseUrl != null && !baseUrl.toString().trim().isEmpty()) {
+            return baseUrl.toString();
+        }
         return req.getScheme() + "://" + req.getServerName() +
                 ":" + req.getServerPort() + req.getContextPath();
     }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/util/PromptKeySupport.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/util/PromptKeySupport.java
@@ -1,8 +1,19 @@
 package com.teknolojikpanda.bitbucket.aireviewer.util;
 
 import java.util.Locale;
+import java.util.Set;
 
 public final class PromptKeySupport {
+
+    private static final Set<String> SUPPORTED_PROMPT_KEYS = Set.of(
+            "prompt.system",
+            "prompt.chunk",
+            "prompt.overview",
+            "prompt.fileline",
+            "prompt.overviewfile",
+            "prompt.system.append",
+            "prompt.chunk.append"
+    );
 
     private PromptKeySupport() {
     }
@@ -11,6 +22,6 @@ public final class PromptKeySupport {
         if (key == null) {
             return false;
         }
-        return key.trim().toLowerCase(Locale.ROOT).startsWith("prompt");
+        return SUPPORTED_PROMPT_KEYS.contains(key.trim().toLowerCase(Locale.ROOT));
     }
 }

--- a/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/util/PromptKeySupport.java
+++ b/src/main/java/com/teknolojikpanda/bitbucket/aireviewer/util/PromptKeySupport.java
@@ -1,0 +1,16 @@
+package com.teknolojikpanda.bitbucket.aireviewer.util;
+
+import java.util.Locale;
+
+public final class PromptKeySupport {
+
+    private PromptKeySupport() {
+    }
+
+    public static boolean isPromptKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        return key.trim().toLowerCase(Locale.ROOT).startsWith("prompt");
+    }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -402,6 +402,7 @@
         <description>Resources for the admin prompt configuration page</description>
         <dependency>com.atlassian.auiplugin:ajs</dependency>
         <dependency>com.atlassian.auiplugin:aui-flag</dependency>
+        <dependency>com.atlassian.bitbucket.server.bitbucket-webpack-INTERNAL:markup-editor</dependency>
         <resource type="download" name="ai-reviewer-admin.css" location="/css/ai-reviewer-admin.css"/>
         <resource type="download" name="ai-reviewer-common.js" location="/js/ai-reviewer-common.js"/>
         <resource type="download" name="ai-reviewer-prompts.js" location="/js/ai-reviewer-prompts.js"/>
@@ -412,6 +413,7 @@
         <description>Resources for the repository prompt settings page</description>
         <dependency>com.atlassian.auiplugin:ajs</dependency>
         <dependency>com.atlassian.auiplugin:aui-flag</dependency>
+        <dependency>com.atlassian.bitbucket.server.bitbucket-webpack-INTERNAL:markup-editor</dependency>
         <resource type="download" name="ai-reviewer-admin.css" location="/css/ai-reviewer-admin.css"/>
         <resource type="download" name="ai-reviewer-common.js" location="/js/ai-reviewer-common.js"/>
         <resource type="download" name="ai-reviewer-repo-settings.js" location="/js/ai-reviewer-repo-settings.js"/>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -291,6 +291,14 @@
         <link>/plugins/servlet/ai-reviewer/admin</link>
     </web-item>
 
+    <web-item key="ai-reviewer-prompts-link"
+              name="AI Code Reviewer Prompts"
+              section="atl.admin/ai-reviewer-admin-section"
+              weight="15">
+        <label>Prompt Customisation</label>
+        <link>/plugins/servlet/ai-reviewer/prompts</link>
+    </web-item>
+
     <web-item key="ai-reviewer-history-link"
               name="AI Review History"
               section="atl.admin/ai-reviewer-admin-section"
@@ -315,12 +323,35 @@
         <link>/plugins/servlet/ai-reviewer/operations</link>
     </web-item>
 
+    <!-- Repository Settings Navigation -->
+    <web-item key="ai-reviewer-repo-settings-link"
+              name="AI Code Reviewer Prompts"
+              section="bitbucket.repository.settings"
+              weight="120">
+        <label>AI Code Reviewer</label>
+        <link>/plugins/servlet/ai-reviewer/repo-config?projectKey=$repository.project.key&amp;repositorySlug=$repository.slug</link>
+    </web-item>
+
     <!-- Admin Configuration Servlet -->
     <servlet key="ai-reviewer-admin-servlet"
              name="AI Reviewer Admin Servlet"
              class="com.teknolojikpanda.bitbucket.aireviewer.servlet.AdminConfigServlet">
         <description>Admin configuration page for AI Code Reviewer</description>
         <url-pattern>/ai-reviewer/admin</url-pattern>
+    </servlet>
+
+    <servlet key="ai-reviewer-prompts-servlet"
+             name="AI Reviewer Prompt Servlet"
+             class="com.teknolojikpanda.bitbucket.aireviewer.servlet.AdminPromptConfigServlet">
+        <description>Admin prompt configuration page for AI Code Reviewer</description>
+        <url-pattern>/ai-reviewer/prompts</url-pattern>
+    </servlet>
+
+    <servlet key="ai-reviewer-repo-config-servlet"
+             name="AI Reviewer Repository Prompt Servlet"
+             class="com.teknolojikpanda.bitbucket.aireviewer.servlet.RepoPromptConfigServlet">
+        <description>Repository prompt configuration page for AI Code Reviewer</description>
+        <url-pattern>/ai-reviewer/repo-config</url-pattern>
     </servlet>
 
     <servlet key="ai-reviewer-history-servlet"
@@ -358,6 +389,26 @@
         <resource type="download" name="ai-reviewer-scope-tree.js" location="/js/ai-reviewer-scope-tree.js"/>
         <resource type="download" name="ai-reviewer-admin.js" location="/js/ai-reviewer-admin.js"/>
         <context>ai-reviewer-admin</context>
+    </web-resource>
+
+    <web-resource key="ai-reviewer-prompts-resources" name="AI Reviewer Prompt Resources">
+        <description>Resources for the admin prompt configuration page</description>
+        <dependency>com.atlassian.auiplugin:ajs</dependency>
+        <dependency>com.atlassian.auiplugin:aui-flag</dependency>
+        <resource type="download" name="ai-reviewer-admin.css" location="/css/ai-reviewer-admin.css"/>
+        <resource type="download" name="ai-reviewer-common.js" location="/js/ai-reviewer-common.js"/>
+        <resource type="download" name="ai-reviewer-prompts.js" location="/js/ai-reviewer-prompts.js"/>
+        <context>ai-reviewer-prompts</context>
+    </web-resource>
+
+    <web-resource key="ai-reviewer-repo-settings-resources" name="AI Reviewer Repository Settings Resources">
+        <description>Resources for the repository prompt settings page</description>
+        <dependency>com.atlassian.auiplugin:ajs</dependency>
+        <dependency>com.atlassian.auiplugin:aui-flag</dependency>
+        <resource type="download" name="ai-reviewer-admin.css" location="/css/ai-reviewer-admin.css"/>
+        <resource type="download" name="ai-reviewer-common.js" location="/js/ai-reviewer-common.js"/>
+        <resource type="download" name="ai-reviewer-repo-settings.js" location="/js/ai-reviewer-repo-settings.js"/>
+        <context>ai-reviewer-repo-settings</context>
     </web-resource>
 
     <web-resource key="ai-reviewer-history-resources" name="AI Reviewer History Resources">

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -324,11 +324,18 @@
     </web-item>
 
     <!-- Repository Settings Navigation -->
+    <web-section key="ai-reviewer-repo-settings-section"
+                 name="AI Code Reviewer"
+                 location="bitbucket.repository.settings.panel"
+                 weight="200">
+        <label>AI Code Reviewer</label>
+    </web-section>
+
     <web-item key="ai-reviewer-repo-settings-link"
               name="AI Code Reviewer Prompts"
-              section="bitbucket.repository.settings"
-              weight="120">
-        <label>AI Code Reviewer</label>
+              section="bitbucket.repository.settings.panel/ai-reviewer-repo-settings-section"
+              weight="10">
+        <label>Prompt Overrides</label>
         <link>/plugins/servlet/ai-reviewer/repo-config?projectKey=$repository.project.key&amp;repositorySlug=$repository.slug</link>
     </web-item>
 

--- a/src/main/resources/css/ai-reviewer-admin.css
+++ b/src/main/resources/css/ai-reviewer-admin.css
@@ -53,6 +53,7 @@
     gap: 10px;
 }
 
+
 #test-connection-result {
     margin-left: 10px;
     display: inline-block;
@@ -769,6 +770,81 @@
 
 #test-connection-btn:hover {
     background-color: #f4f5f7;
+}
+
+/* Native Bitbucket markup editor alignment in prompt settings */
+#ai-reviewer-prompts-container .markup-editor,
+#ai-reviewer-repo-config .markup-editor {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+#ai-reviewer-prompts-container .markup-editor textarea,
+#ai-reviewer-repo-config .markup-editor textarea {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    display: block;
+}
+
+#ai-reviewer-prompts-container .markup-editor .markup-toolbar,
+#ai-reviewer-repo-config .markup-editor .markup-toolbar {
+    padding: 8px 10px;
+    min-height: 38px;
+    box-sizing: border-box;
+    display: flow-root;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+#ai-reviewer-prompts-container .markup-editor.preview-only .markup-toolbar,
+#ai-reviewer-repo-config .markup-editor.preview-only .markup-toolbar {
+    display: none;
+}
+
+#ai-reviewer-prompts-container .markup-editor.preview-only textarea,
+#ai-reviewer-repo-config .markup-editor.preview-only textarea {
+    display: none !important;
+}
+
+#ai-reviewer-prompts-container .markup-editor.preview-only .markup-preview,
+#ai-reviewer-repo-config .markup-editor.preview-only .markup-preview {
+    display: block !important;
+    min-height: 220px;
+    border: 1px solid #dfe1e6;
+    border-radius: 4px;
+    padding: 12px 14px;
+    background: #ffffff;
+}
+
+#ai-reviewer-prompts-container .markup-editor.preview-only .markup-preview,
+#ai-reviewer-prompts-container .markup-editor.preview-only textarea,
+#ai-reviewer-repo-config .markup-editor.preview-only .markup-preview,
+#ai-reviewer-repo-config .markup-editor.preview-only textarea {
+    cursor: default;
+}
+
+#ai-reviewer-prompts-container .markup-editor.preview-only .aui-spinner,
+#ai-reviewer-prompts-container .markup-editor.preview-only .spinner,
+#ai-reviewer-repo-config .markup-editor.preview-only .aui-spinner,
+#ai-reviewer-repo-config .markup-editor.preview-only .spinner {
+    display: none !important;
+}
+
+#ai-reviewer-prompts-container .markup-editor.preview-only .expandingText,
+#ai-reviewer-prompts-container .markup-editor.preview-only .expandingText *,
+#ai-reviewer-repo-config .markup-editor.preview-only .expandingText,
+#ai-reviewer-repo-config .markup-editor.preview-only .expandingText * {
+    display: none !important;
+}
+
+#ai-reviewer-prompts-container .markup-editor .markup-toolbar .secondary,
+#ai-reviewer-repo-config .markup-editor .markup-toolbar .secondary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
 }
 
 /* Icon Styling */

--- a/src/main/resources/js/ai-reviewer-admin.js
+++ b/src/main/resources/js/ai-reviewer-admin.js
@@ -117,6 +117,7 @@
         $('#ignore-paths').val(config.ignorePaths || '');
         $('#auto-approve').prop('checked', config.autoApprove === true);
         $('#worker-degradation-enabled').prop('checked', config.workerDegradationEnabled !== false);
+    $('#verbose-mode').prop('checked', config.verboseMode === true);
 
         // Checkboxes
         $('#enabled').prop('checked', config.enabled !== false);
@@ -1431,6 +1432,7 @@
             skipTests: $('#skip-tests').is(':checked'),
             autoApprove: $('#auto-approve').is(':checked'),
             workerDegradationEnabled: $('#worker-degradation-enabled').is(':checked'),
+            verboseMode: $('#verbose-mode').is(':checked'),
             aiReviewerUser: reviewerUser && reviewerUser.length ? reviewerUser : null
         };
 
@@ -1604,7 +1606,8 @@
             skipGeneratedFiles: true,
             skipTests: false,
             autoApprove: false,
-            workerDegradationEnabled: true
+            workerDegradationEnabled: true,
+            verboseMode: false
         };
 
         defaults.profilePresets = Object.values(profilePresets);

--- a/src/main/resources/js/ai-reviewer-admin.js
+++ b/src/main/resources/js/ai-reviewer-admin.js
@@ -1382,6 +1382,13 @@
         }
     }
 
+    function normalizePromptText(text) {
+        if (!text) {
+            return '';
+        }
+        return text.trim();
+    }
+
     /**
      * Collect form data into configuration object
      */
@@ -1391,7 +1398,7 @@
         var overviewRetryDelay = parseInt($('#overview-retry-delay').val());
         var chunkMaxRetries = parseInt($('#chunk-max-retries').val());
         var chunkRetryDelay = parseInt($('#chunk-retry-delay').val());
-        return {
+        var config = {
             ollamaUrl: $('#ollama-url').val().trim(),
             ollamaModel: $('#ollama-model').val().trim(),
             fallbackModel: $('#fallback-model').val().trim(),
@@ -1426,6 +1433,25 @@
             workerDegradationEnabled: $('#worker-degradation-enabled').is(':checked'),
             aiReviewerUser: reviewerUser && reviewerUser.length ? reviewerUser : null
         };
+
+        var promptChunk = $('#prompt-chunk').val();
+        var promptChunkDefault = $('#prompt-chunk-default').val() || '';
+        if (promptChunk && normalizePromptText(promptChunk).length) {
+            if (normalizePromptText(promptChunk) === normalizePromptText(promptChunkDefault)) {
+                config['prompt.chunk'] = null;
+            } else {
+                config['prompt.chunk'] = promptChunk;
+            }
+        } else {
+            config['prompt.chunk'] = null;
+        }
+
+        var promptSystemAppend = $('#prompt-system-append').val();
+        config['prompt.system.append'] = normalizePromptText(promptSystemAppend).length
+            ? promptSystemAppend
+            : null;
+
+        return config;
     }
 
     function synchronizeRepositoryScope() {

--- a/src/main/resources/js/ai-reviewer-prompts.js
+++ b/src/main/resources/js/ai-reviewer-prompts.js
@@ -1,0 +1,135 @@
+(function($) {
+    'use strict';
+
+    var baseUrl = AJS.$('meta[name="application-base-url"]').attr('content') ||
+        AJS.$('meta[name="ajs-context-path"]').attr('content') ||
+        window.location.origin + (AJS.contextPath() || '');
+
+    var apiUrl = baseUrl + '/rest/ai-reviewer/1.0/config';
+
+    function init() {
+        $('#ai-reviewer-prompts-form').on('submit', handleSubmit);
+        $('#reset-prompts-btn').on('click', handleReset);
+        refreshPrompts();
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+        savePrompts();
+    }
+
+    function handleReset() {
+        $('#prompt-chunk').val('');
+        $('#prompt-system-append').val('');
+        savePrompts();
+    }
+
+    function refreshPrompts() {
+        showLoading(true);
+        $.ajax({
+            url: apiUrl,
+            type: 'GET',
+            dataType: 'json',
+            success: function(config) {
+                applyConfig(config || {});
+                showLoading(false);
+            },
+            error: function(xhr, status, error) {
+                var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';
+                showMessage('error', 'Failed to load prompt configuration: ' + message);
+                showLoading(false);
+            }
+        });
+    }
+
+    function applyConfig(config) {
+        var defaultSystem = $('#prompt-system-default').val() || '';
+        var defaultChunk = $('#prompt-chunk-default').val() || '';
+        $('#prompt-chunk').val(config['prompt.chunk'] || '');
+        $('#prompt-system-append').val(config['prompt.system.append'] || '');
+
+        var effectiveSystem = defaultSystem;
+        if (config['prompt.system.append']) {
+            var systemAppend = config['prompt.system.append'];
+            if (systemAppend.trim().length) {
+                effectiveSystem += (effectiveSystem.endsWith('\n') ? '' : '\n') + systemAppend;
+            }
+        }
+        $('#prompt-system-effective').val(effectiveSystem);
+
+        var effectiveChunk = config['prompt.chunk'] || defaultChunk;
+        var chunkAppend = config['prompt.chunk.append'];
+        if (chunkAppend && chunkAppend.trim().length) {
+            effectiveChunk += (effectiveChunk.endsWith('\n') ? '' : '\n') + chunkAppend;
+        }
+        $('#prompt-chunk-effective').val(effectiveChunk);
+        autoResizeAll();
+    }
+
+    function savePrompts() {
+        var payload = {
+            'prompt.chunk': $('#prompt-chunk').val(),
+            'prompt.system.append': $('#prompt-system-append').val()
+        };
+        showLoading(true);
+        $.ajax({
+            url: apiUrl,
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify(payload),
+            success: function() {
+                showMessage('success', 'Prompt settings saved.');
+                refreshPrompts();
+            },
+            error: function(xhr, status, error) {
+                var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';
+                showMessage('error', 'Failed to save prompt settings: ' + message);
+                showLoading(false);
+            }
+        });
+    }
+
+    function showLoading(show) {
+        $('#loading-indicator').toggle(!!show);
+        $('#save-prompts-btn').prop('disabled', !!show);
+        $('#reset-prompts-btn').prop('disabled', !!show);
+    }
+
+    function showMessage(type, message) {
+        var $container = $('#aui-message-container');
+        $container.empty();
+        if (!message) {
+            return;
+        }
+        var messageClass = 'aui-message-' + type;
+        var iconClass = type === 'error' ? 'error' : type === 'success' ? 'success' : 'info';
+        var $message = $('<div class="aui-message ' + messageClass + ' closeable">')
+            .append('<p class="title"><span class="aui-icon icon-' + iconClass + '"></span><strong>' +
+                    (type.charAt(0).toUpperCase() + type.slice(1)) + '</strong></p>')
+            .append('<p>' + message + '</p>')
+            .append('<span class="aui-icon icon-close" role="button" tabindex="0"></span>');
+        $container.append($message);
+        $message.find('.icon-close').on('click', function() {
+            $message.fadeOut(function() {
+                $(this).remove();
+            });
+        });
+    }
+
+    function autoResizeAll() {
+        ['#prompt-system-effective', '#prompt-chunk-effective', '#prompt-chunk', '#prompt-system-append']
+            .forEach(function(selector) {
+                autoResize($(selector));
+            });
+    }
+
+    function autoResize($textarea) {
+        if (!$textarea || !$textarea.length) {
+            return;
+        }
+        $textarea.css('height', 'auto');
+        $textarea.css('height', $textarea[0].scrollHeight + 12 + 'px');
+    }
+
+    AJS.toInit(init);
+})(AJS.$);

--- a/src/main/resources/js/ai-reviewer-prompts.js
+++ b/src/main/resources/js/ai-reviewer-prompts.js
@@ -185,7 +185,8 @@
             data: JSON.stringify(payload),
             success: function() {
                 showMessage('success', 'Prompt settings saved.');
-                refreshPrompts();
+                applyConfig(payload || {});
+                showLoading(false);
             },
             error: function(xhr, status, error) {
                 var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';
@@ -212,7 +213,7 @@
         var $message = $('<div class="aui-message ' + messageClass + ' closeable">')
             .append('<p class="title"><span class="aui-icon icon-' + iconClass + '"></span><strong>' +
                     (type.charAt(0).toUpperCase() + type.slice(1)) + '</strong></p>')
-            .append('<p>' + message + '</p>')
+            .append($('<p></p>').text(message))
             .append('<span class="aui-icon icon-close" role="button" tabindex="0"></span>');
         $container.append($message);
         $message.find('.icon-close').on('click', function() {

--- a/src/main/resources/js/ai-reviewer-prompts.js
+++ b/src/main/resources/js/ai-reviewer-prompts.js
@@ -46,14 +46,26 @@
         var defaultSystem = $('#prompt-system-default').val() || '';
         var defaultChunk = $('#prompt-chunk-default').val() || '';
         $('#prompt-chunk').val(config['prompt.chunk'] || '');
-        $('#prompt-system-append').val(config['prompt.system.append'] || '');
+        var configSystemAppend = typeof config['prompt.system.append'] !== 'undefined'
+            ? config['prompt.system.append']
+            : config.promptSystemAppend;
+        if (typeof configSystemAppend === 'undefined') {
+            configSystemAppend = $('#prompt-system-append').val();
+        }
+        $('#prompt-system-append').val(configSystemAppend || '');
 
         var effectiveSystem = defaultSystem;
-        if (config['prompt.system.append']) {
-            var systemAppend = config['prompt.system.append'];
-            if (systemAppend.trim().length) {
-                effectiveSystem += (effectiveSystem.endsWith('\n') ? '' : '\n') + systemAppend;
+        var systemAppend = configSystemAppend;
+        var placeholder = '{{ADDITIONAL_INSTRUCTIONS}}';
+        if (systemAppend && systemAppend.trim().length) {
+            var replacement = 'ADDITIONAL INSTRUCTIONS:\n' + systemAppend.trim();
+            if (effectiveSystem.indexOf(placeholder) >= 0) {
+                effectiveSystem = effectiveSystem.split(placeholder).join(replacement);
+            } else {
+                effectiveSystem += (effectiveSystem.endsWith('\n') ? '' : '\n') + replacement;
             }
+        } else if (effectiveSystem.indexOf(placeholder) >= 0) {
+            effectiveSystem = effectiveSystem.split(placeholder).join('').trim();
         }
         $('#prompt-system-effective').val(effectiveSystem);
 
@@ -67,9 +79,11 @@
     }
 
     function savePrompts() {
+        var chunkValue = $('#prompt-chunk').val();
+        var systemAppendValue = $('#prompt-system-append').val();
         var payload = {
-            'prompt.chunk': $('#prompt-chunk').val(),
-            'prompt.system.append': $('#prompt-system-append').val()
+            'prompt.chunk': chunkValue && chunkValue.trim().length ? chunkValue : null,
+            'prompt.system.append': systemAppendValue && systemAppendValue.trim().length ? systemAppendValue : null
         };
         showLoading(true);
         $.ajax({

--- a/src/main/resources/js/ai-reviewer-prompts.js
+++ b/src/main/resources/js/ai-reviewer-prompts.js
@@ -7,6 +7,7 @@
 
     var apiUrl = baseUrl + '/rest/ai-reviewer/1.0/config';
     var effectiveEditorsReady = false;
+    var pendingEffectivePreview = false;
 
     function init() {
         initMarkupEditors();
@@ -38,6 +39,9 @@
                 lockEffectivePreview($effectiveChunkEditor);
             }
             effectiveEditorsReady = true;
+            if (pendingEffectivePreview) {
+                triggerEffectivePreviews();
+            }
             bindPreviewSpinnerFix($chunkEditor);
             bindPreviewSpinnerFix($systemEditor);
             bindPreviewSpinnerFix($effectiveSystemEditor);
@@ -137,22 +141,33 @@
 
     function triggerEffectivePreviews() {
         if (!effectiveEditorsReady) {
+            pendingEffectivePreview = true;
             return;
         }
+        pendingEffectivePreview = false;
         triggerPreviewFor('#prompt-system-effective-editor');
         triggerPreviewFor('#prompt-chunk-effective-editor');
     }
 
     function triggerPreviewFor(selector) {
         var $editor = $(selector);
-        if (!$editor.length || $editor.hasClass('previewing')) {
+        if (!$editor.length) {
             return;
         }
         var $previewButton = $editor.find('.markup-preview-button');
-        if ($previewButton.length) {
-            $previewButton.trigger('click');
-            stopPreviewSpinner($editor);
+        if (!$previewButton.length) {
+            return;
         }
+        if ($editor.hasClass('previewing')) {
+            $previewButton.trigger('click');
+            setTimeout(function() {
+                $previewButton.trigger('click');
+                stopPreviewSpinner($editor);
+            }, 0);
+            return;
+        }
+        $previewButton.trigger('click');
+        stopPreviewSpinner($editor);
     }
 
     function stopPreviewSpinner($editor) {
@@ -185,8 +200,7 @@
             data: JSON.stringify(payload),
             success: function() {
                 showMessage('success', 'Prompt settings saved.');
-                applyConfig(payload || {});
-                showLoading(false);
+                refreshPrompts();
             },
             error: function(xhr, status, error) {
                 var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';

--- a/src/main/resources/js/ai-reviewer-prompts.js
+++ b/src/main/resources/js/ai-reviewer-prompts.js
@@ -8,6 +8,8 @@
     var apiUrl = baseUrl + '/rest/ai-reviewer/1.0/config';
     var effectiveEditorsReady = false;
     var pendingEffectivePreview = false;
+    var PROMPT_PLACEHOLDER = '{{ADDITIONAL_INSTRUCTIONS}}';
+    var ADDITIONAL_HEADER = 'ADDITIONAL INSTRUCTIONS:\n';
 
     function init() {
         initMarkupEditors();
@@ -28,25 +30,28 @@
             var $systemEditor = $('#prompt-system-append-editor');
             var $effectiveSystemEditor = $('#prompt-system-effective-editor');
             var $effectiveChunkEditor = $('#prompt-chunk-effective-editor');
-            MarkupEditor.bindTo($chunkEditor);
-            MarkupEditor.bindTo($systemEditor);
-            if ($effectiveSystemEditor.length) {
-                MarkupEditor.bindTo($effectiveSystemEditor);
-                lockEffectivePreview($effectiveSystemEditor);
-            }
-            if ($effectiveChunkEditor.length) {
-                MarkupEditor.bindTo($effectiveChunkEditor);
-                lockEffectivePreview($effectiveChunkEditor);
-            }
+
+            setupMarkupEditor(MarkupEditor, $chunkEditor);
+            setupMarkupEditor(MarkupEditor, $systemEditor);
+            setupMarkupEditor(MarkupEditor, $effectiveSystemEditor, { lockPreview: true });
+            setupMarkupEditor(MarkupEditor, $effectiveChunkEditor, { lockPreview: true });
+
             effectiveEditorsReady = true;
             if (pendingEffectivePreview) {
                 triggerEffectivePreviews();
             }
-            bindPreviewSpinnerFix($chunkEditor);
-            bindPreviewSpinnerFix($systemEditor);
-            bindPreviewSpinnerFix($effectiveSystemEditor);
-            bindPreviewSpinnerFix($effectiveChunkEditor);
         });
+    }
+
+    function setupMarkupEditor(MarkupEditor, $editor, options) {
+        if (!MarkupEditor || !$editor || !$editor.length) {
+            return;
+        }
+        MarkupEditor.bindTo($editor);
+        if (options && options.lockPreview) {
+            lockEffectivePreview($editor);
+        }
+        bindPreviewSpinnerFix($editor);
     }
 
     function lockEffectivePreview($editor) {
@@ -103,40 +108,68 @@
     }
 
     function applyConfig(config) {
-        var defaultSystem = $('#prompt-system-default').val() || '';
-        var defaultChunk = $('#prompt-chunk-default').val() || '';
+        var defaults = {
+            system: $('#prompt-system-default').val() || '',
+            chunk: $('#prompt-chunk-default').val() || ''
+        };
+        var currentValues = {
+            systemAppend: $('#prompt-system-append').val()
+        };
+        var effectiveFromServer = config.promptEffective || {};
+        var result = computeEffectivePrompts(config, defaults, currentValues, effectiveFromServer);
+
         $('#prompt-chunk').val(config['prompt.chunk'] || '');
-        var configSystemAppend = typeof config['prompt.system.append'] !== 'undefined'
-            ? config['prompt.system.append']
-            : config.promptSystemAppend;
-        if (typeof configSystemAppend === 'undefined') {
-            configSystemAppend = $('#prompt-system-append').val();
-        }
-        $('#prompt-system-append').val(configSystemAppend || '');
-
-        var effectiveSystem = defaultSystem;
-        var systemAppend = configSystemAppend;
-        var placeholder = '{{ADDITIONAL_INSTRUCTIONS}}';
-        if (systemAppend && systemAppend.trim().length) {
-            var replacement = 'ADDITIONAL INSTRUCTIONS:\n' + systemAppend.trim();
-            if (effectiveSystem.indexOf(placeholder) >= 0) {
-                effectiveSystem = effectiveSystem.split(placeholder).join(replacement);
-            } else {
-                effectiveSystem += (effectiveSystem.endsWith('\n') ? '' : '\n') + replacement;
-            }
-        } else if (effectiveSystem.indexOf(placeholder) >= 0) {
-            effectiveSystem = effectiveSystem.split(placeholder).join('').trim();
-        }
-        $('#prompt-system-effective').val(effectiveSystem);
-
-        var effectiveChunk = config['prompt.chunk'] || defaultChunk;
-        var chunkAppend = config['prompt.chunk.append'];
-        if (chunkAppend && chunkAppend.trim().length) {
-            effectiveChunk += (effectiveChunk.endsWith('\n') ? '' : '\n') + chunkAppend;
-        }
-        $('#prompt-chunk-effective').val(effectiveChunk);
+        $('#prompt-system-append').val(result.systemAppend);
+        $('#prompt-system-effective').val(result.effectiveSystem);
+        $('#prompt-chunk-effective').val(result.effectiveChunk);
         triggerEffectivePreviews();
         autoResizeAll();
+    }
+
+    function computeEffectivePrompts(config, defaults, currentValues, effectiveFromServer) {
+        var systemAppend = resolveSystemAppend(config, currentValues);
+        var effectiveSystem = effectiveFromServer['prompt.system'] ||
+            renderAdditionalInstructions(defaults.system || '', systemAppend);
+
+        var baseChunk = config['prompt.chunk'] || defaults.chunk || '';
+        var chunkAppend = config['prompt.chunk.append'];
+        var effectiveChunk = effectiveFromServer['prompt.chunk'] ||
+            renderAdditionalInstructions(baseChunk, chunkAppend);
+
+        return {
+            systemAppend: systemAppend || '',
+            effectiveSystem: effectiveSystem,
+            effectiveChunk: effectiveChunk
+        };
+    }
+
+    function resolveSystemAppend(config, currentValues) {
+        if (typeof config['prompt.system.append'] !== 'undefined') {
+            return config['prompt.system.append'];
+        }
+        if (typeof config.promptSystemAppend !== 'undefined') {
+            return config.promptSystemAppend;
+        }
+        return (currentValues && currentValues.systemAppend) ? currentValues.systemAppend : '';
+    }
+
+    function renderAdditionalInstructions(base, addition) {
+        var trimmedAddition = (addition || '').trim();
+        var hasAddition = trimmedAddition.length > 0;
+        var hasPlaceholder = base.indexOf(PROMPT_PLACEHOLDER) >= 0;
+
+        if (hasPlaceholder) {
+            if (!hasAddition) {
+                return base.split(PROMPT_PLACEHOLDER).join('').trim();
+            }
+            return base.split(PROMPT_PLACEHOLDER).join(ADDITIONAL_HEADER + trimmedAddition).trim();
+        }
+
+        if (!hasAddition) {
+            return base;
+        }
+
+        return base + (base.endsWith('\n') ? '' : '\n') + ADDITIONAL_HEADER + trimmedAddition;
     }
 
     function triggerEffectivePreviews() {
@@ -198,16 +231,18 @@
             type: 'PUT',
             contentType: 'application/json',
             data: JSON.stringify(payload),
-            success: function() {
-                showMessage('success', 'Prompt settings saved.');
-                refreshPrompts();
-            },
+            success: handleSuccessfulSave,
             error: function(xhr, status, error) {
                 var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';
                 showMessage('error', 'Failed to save prompt settings: ' + message);
                 showLoading(false);
             }
         });
+    }
+
+    function handleSuccessfulSave() {
+        showMessage('success', 'Prompt settings saved.');
+        refreshPrompts();
     }
 
     function showLoading(show) {

--- a/src/main/resources/js/ai-reviewer-prompts.js
+++ b/src/main/resources/js/ai-reviewer-prompts.js
@@ -6,11 +6,67 @@
         window.location.origin + (AJS.contextPath() || '');
 
     var apiUrl = baseUrl + '/rest/ai-reviewer/1.0/config';
+    var effectiveEditorsReady = false;
 
     function init() {
+        initMarkupEditors();
         $('#ai-reviewer-prompts-form').on('submit', handleSubmit);
         $('#reset-prompts-btn').on('click', handleReset);
         refreshPrompts();
+    }
+
+    function initMarkupEditors() {
+        if (typeof require !== 'function') {
+            return;
+        }
+        require(['bitbucket/internal/widget/markup-editor/markup-editor'], function(MarkupEditor) {
+            if (!MarkupEditor || !MarkupEditor.bindTo) {
+                return;
+            }
+            var $chunkEditor = $('#prompt-chunk-editor');
+            var $systemEditor = $('#prompt-system-append-editor');
+            var $effectiveSystemEditor = $('#prompt-system-effective-editor');
+            var $effectiveChunkEditor = $('#prompt-chunk-effective-editor');
+            MarkupEditor.bindTo($chunkEditor);
+            MarkupEditor.bindTo($systemEditor);
+            if ($effectiveSystemEditor.length) {
+                MarkupEditor.bindTo($effectiveSystemEditor);
+                lockEffectivePreview($effectiveSystemEditor);
+            }
+            if ($effectiveChunkEditor.length) {
+                MarkupEditor.bindTo($effectiveChunkEditor);
+                lockEffectivePreview($effectiveChunkEditor);
+            }
+            effectiveEditorsReady = true;
+            bindPreviewSpinnerFix($chunkEditor);
+            bindPreviewSpinnerFix($systemEditor);
+            bindPreviewSpinnerFix($effectiveSystemEditor);
+            bindPreviewSpinnerFix($effectiveChunkEditor);
+        });
+    }
+
+    function lockEffectivePreview($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        $editor.off('click', '.markup-preview');
+        $editor.off('click', 'textarea');
+        $editor.on('click', '.markup-preview, textarea', function(event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        });
+    }
+
+    function bindPreviewSpinnerFix($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        $editor.on('click', '.markup-preview-button, .markup-preview', function() {
+            var $target = $editor.find('textarea').parent();
+            if ($target && $target.spinStop) {
+                $target.spinStop();
+            }
+        });
     }
 
     function handleSubmit(event) {
@@ -75,7 +131,43 @@
             effectiveChunk += (effectiveChunk.endsWith('\n') ? '' : '\n') + chunkAppend;
         }
         $('#prompt-chunk-effective').val(effectiveChunk);
+        triggerEffectivePreviews();
         autoResizeAll();
+    }
+
+    function triggerEffectivePreviews() {
+        if (!effectiveEditorsReady) {
+            return;
+        }
+        triggerPreviewFor('#prompt-system-effective-editor');
+        triggerPreviewFor('#prompt-chunk-effective-editor');
+    }
+
+    function triggerPreviewFor(selector) {
+        var $editor = $(selector);
+        if (!$editor.length || $editor.hasClass('previewing')) {
+            return;
+        }
+        var $previewButton = $editor.find('.markup-preview-button');
+        if ($previewButton.length) {
+            $previewButton.trigger('click');
+            stopPreviewSpinner($editor);
+        }
+    }
+
+    function stopPreviewSpinner($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        var $target = $editor.find('textarea').parent();
+        if ($target && $target.spinStop) {
+            $target.spinStop();
+        }
+        setTimeout(function() {
+            if ($target && $target.spinStop) {
+                $target.spinStop();
+            }
+        }, 150);
     }
 
     function savePrompts() {
@@ -131,7 +223,7 @@
     }
 
     function autoResizeAll() {
-        ['#prompt-system-effective', '#prompt-chunk-effective', '#prompt-chunk', '#prompt-system-append']
+        ['#prompt-system-effective', '#prompt-chunk-effective']
             .forEach(function(selector) {
                 autoResize($(selector));
             });

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -12,6 +12,8 @@
     var repositorySlug = $container.data('repositorySlug') || $container.data('repository-slug') ||
         AJS.$('meta[name="repositorySlug"]').attr('content');
     var effectivePreviewReady = false;
+    var PROMPT_PLACEHOLDER = '{{ADDITIONAL_INSTRUCTIONS}}';
+    var ADDITIONAL_HEADER = 'ADDITIONAL INSTRUCTIONS:\n';
 
     function resolveContextFromQuery() {
         var params = new URLSearchParams(window.location.search || '');
@@ -62,17 +64,26 @@
             var $overrideEditor = $('#repo-prompt-override-editor');
             var $appendEditor = $('#repo-prompt-append-editor');
             var $effectiveEditor = $('#repo-prompt-effective-editor');
-            MarkupEditor.bindTo($overrideEditor);
-            MarkupEditor.bindTo($appendEditor);
+
+            setupMarkupEditor(MarkupEditor, $overrideEditor);
+            setupMarkupEditor(MarkupEditor, $appendEditor);
+            setupMarkupEditor(MarkupEditor, $effectiveEditor, { lockPreview: true });
+
             if ($effectiveEditor.length) {
-                MarkupEditor.bindTo($effectiveEditor);
-                lockEffectivePreview($effectiveEditor);
                 effectivePreviewReady = true;
             }
-            bindPreviewSpinnerFix($overrideEditor);
-            bindPreviewSpinnerFix($appendEditor);
-            bindPreviewSpinnerFix($effectiveEditor);
         });
+    }
+
+    function setupMarkupEditor(MarkupEditor, $editor, options) {
+        if (!MarkupEditor || !$editor || !$editor.length) {
+            return;
+        }
+        MarkupEditor.bindTo($editor);
+        if (options && options.lockPreview) {
+            lockEffectivePreview($editor);
+        }
+        bindPreviewSpinnerFix($editor);
     }
 
     function lockEffectivePreview($editor) {
@@ -125,19 +136,20 @@
 
     function buildOverridesPayload() {
         var overrides = $.extend({}, currentOverrides || {});
-        var overrideText = $('#repo-prompt-override').val();
-        if (overrideText && overrideText.trim().length) {
-            overrides['prompt.chunk'] = overrideText;
-        } else {
-            delete overrides['prompt.chunk'];
-        }
-        var appendText = $('#repo-prompt-append').val();
-        if (appendText && appendText.trim().length) {
-            overrides['prompt.chunk.append'] = appendText;
-        } else {
-            delete overrides['prompt.chunk.append'];
-        }
+        overrides['prompt.chunk'] = normalizeOverrideValue($('#repo-prompt-override').val());
+        overrides['prompt.chunk.append'] = normalizeOverrideValue($('#repo-prompt-append').val());
+
+        Object.keys(overrides).forEach(function(key) {
+            if (overrides[key] === null) {
+                delete overrides[key];
+            }
+        });
         return overrides;
+    }
+
+    function normalizeOverrideValue(text) {
+        var trimmed = (text || '').trim();
+        return trimmed.length ? text : null;
     }
 
     function loadConfiguration() {
@@ -211,24 +223,42 @@
     }
 
     function updatePromptPreview(response) {
-        var defaults = response.defaults || {};
-        var globalConfig = response.global || {};
-        var overrides = response.overrides || currentOverrides || {};
-        var effective = response.effective || {};
-        var defaultTemplate = $('#prompt-chunk-default').val() || defaults['prompt.chunk'] || '';
-        var globalTemplate = globalConfig['prompt.chunk'];
-        var repoTemplate = overrides['prompt.chunk'];
-        var baseTemplate = repoTemplate || globalTemplate || defaultTemplate;
-
-        var appendText = effective['prompt.chunk.append'] || '';
-        var effectivePrompt = baseTemplate || '';
-        if (appendText && appendText.trim().length) {
-            effectivePrompt += (effectivePrompt.endsWith('\n') ? '' : '\n') +
-                '\nADDITIONAL INSTRUCTIONS:\n' + appendText.trim();
+        var effectivePrompts = response.promptEffective || {};
+        var effectivePrompt = effectivePrompts['prompt.chunk'];
+        if (!effectivePrompt) {
+            var defaults = response.defaults || {};
+            var globalConfig = response.global || {};
+            var overrides = response.overrides || currentOverrides || {};
+            var effective = response.effective || {};
+            var defaultTemplate = $('#prompt-chunk-default').val() || defaults['prompt.chunk'] || '';
+            var globalTemplate = globalConfig['prompt.chunk'];
+            var repoTemplate = overrides['prompt.chunk'];
+            var baseTemplate = repoTemplate || globalTemplate || defaultTemplate;
+            var appendText = effective['prompt.chunk.append'] || '';
+            effectivePrompt = renderAdditionalInstructions(baseTemplate || '', appendText);
         }
-        $('#repo-prompt-effective').val(effectivePrompt);
+        $('#repo-prompt-effective').val(effectivePrompt || '');
         triggerEffectivePreview();
         autoResizeAll();
+    }
+
+    function renderAdditionalInstructions(base, addition) {
+        var trimmedAddition = (addition || '').trim();
+        var hasAddition = trimmedAddition.length > 0;
+        var hasPlaceholder = base.indexOf(PROMPT_PLACEHOLDER) >= 0;
+
+        if (hasPlaceholder) {
+            if (!hasAddition) {
+                return base.split(PROMPT_PLACEHOLDER).join('').trim();
+            }
+            return base.split(PROMPT_PLACEHOLDER).join(ADDITIONAL_HEADER + trimmedAddition).trim();
+        }
+
+        if (!hasAddition) {
+            return base;
+        }
+
+        return base + (base.endsWith('\n') ? '' : '\n') + ADDITIONAL_HEADER + trimmedAddition;
     }
 
     function triggerEffectivePreview() {

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -158,7 +158,8 @@
         var appendText = effective['prompt.chunk.append'] || '';
         var effectivePrompt = baseTemplate || '';
         if (appendText && appendText.trim().length) {
-            effectivePrompt += (effectivePrompt.endsWith('\n') ? '' : '\n') + appendText;
+            effectivePrompt += (effectivePrompt.endsWith('\n') ? '' : '\n') +
+                '\nADDITIONAL INSTRUCTIONS:\n' + appendText.trim();
         }
         $('#repo-prompt-effective').val(effectivePrompt);
         autoResizeAll();

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -92,11 +92,23 @@
             return;
         }
         $editor.on('click', '.markup-preview-button, .markup-preview', function() {
-            var $target = $editor.find('textarea').parent();
+            stopSpinnerForEditor($editor);
+        });
+    }
+
+    function stopSpinnerForEditor($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        var $target = $editor.find('textarea').parent();
+        if ($target && $target.spinStop) {
+            $target.spinStop();
+        }
+        setTimeout(function() {
             if ($target && $target.spinStop) {
                 $target.spinStop();
             }
-        });
+        }, 150);
     }
 
     function handleSubmit(event) {
@@ -139,10 +151,7 @@
             type: 'GET',
             dataType: 'json',
             success: function(response) {
-                currentOverrides = response && response.overrides ? response.overrides : {};
-                $('#repo-prompt-override').val(currentOverrides['prompt.chunk'] || '');
-                $('#repo-prompt-append').val(currentOverrides['prompt.chunk.append'] || '');
-                updatePromptPreview(response || {});
+                applyConfigResponse(response);
                 showLoading(false);
             },
             error: function(xhr, status, error) {
@@ -161,10 +170,7 @@
             contentType: 'application/json',
             data: JSON.stringify(overrides || {}),
             success: function(response) {
-                currentOverrides = response && response.overrides ? response.overrides : (overrides || {});
-                $('#repo-prompt-override').val(currentOverrides['prompt.chunk'] || '');
-                $('#repo-prompt-append').val(currentOverrides['prompt.chunk.append'] || '');
-                updatePromptPreview(response || {});
+                applyConfigResponse(response, overrides || {});
                 showMessage('success', 'Repository prompt instructions saved.');
                 showLoading(false);
             },
@@ -195,10 +201,19 @@
         $container.append($message);
     }
 
+    function applyConfigResponse(response, fallbackOverrides) {
+        response = response || {};
+        var overrides = response.overrides || fallbackOverrides || {};
+        currentOverrides = overrides;
+        $('#repo-prompt-override').val(overrides['prompt.chunk'] || '');
+        $('#repo-prompt-append').val(overrides['prompt.chunk.append'] || '');
+        updatePromptPreview(response);
+    }
+
     function updatePromptPreview(response) {
         var defaults = response.defaults || {};
         var globalConfig = response.global || {};
-        var overrides = response.overrides || {};
+        var overrides = response.overrides || currentOverrides || {};
         var effective = response.effective || {};
         var defaultTemplate = $('#prompt-chunk-default').val() || defaults['prompt.chunk'] || '';
         var globalTemplate = globalConfig['prompt.chunk'];
@@ -230,23 +245,8 @@
         }
         if ($previewButton.length) {
             $previewButton.trigger('click');
-            stopEffectiveSpinner($editor);
+            stopSpinnerForEditor($editor);
         }
-    }
-
-    function stopEffectiveSpinner($editor) {
-        if (!$editor || !$editor.length) {
-            return;
-        }
-        var $target = $editor.find('textarea').parent();
-        if ($target && $target.spinStop) {
-            $target.spinStop();
-        }
-        setTimeout(function() {
-            if ($target && $target.spinStop) {
-                $target.spinStop();
-            }
-        }, 150);
     }
 
     function autoResizeAll() {

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -6,15 +6,44 @@
         window.location.origin + (AJS.contextPath() || '');
 
     var $container = $('#ai-reviewer-repo-config');
-    var projectKey = $container.data('project-key');
-    var repositorySlug = $container.data('repository-slug');
+    var repositoryId = $container.data('repositoryId') || $container.data('repository-id');
+    var projectKey = $container.data('projectKey') || $container.data('project-key') ||
+        AJS.$('meta[name="projectKey"]').attr('content');
+    var repositorySlug = $container.data('repositorySlug') || $container.data('repository-slug') ||
+        AJS.$('meta[name="repositorySlug"]').attr('content');
 
-    var apiUrl = baseUrl + '/rest/ai-reviewer/1.0/config/repositories/' +
-        encodeURIComponent(projectKey) + '/' + encodeURIComponent(repositorySlug);
+    function resolveContextFromQuery() {
+        var params = new URLSearchParams(window.location.search || '');
+        var queryProjectKey = params.get('projectKey');
+        var queryRepositorySlug = params.get('repositorySlug');
+        var queryRepositoryId = params.get('repositoryId');
+        if (!repositoryId && queryRepositoryId) {
+            repositoryId = queryRepositoryId;
+            $container.attr('data-repository-id', repositoryId);
+        }
+        if (!projectKey && queryProjectKey) {
+            projectKey = queryProjectKey;
+            $container.attr('data-project-key', projectKey);
+        }
+        if (!repositorySlug && queryRepositorySlug) {
+            repositorySlug = queryRepositorySlug;
+            $container.attr('data-repository-slug', repositorySlug);
+        }
+    }
+
+    function buildApiUrl() {
+        if (repositoryId) {
+            return baseUrl + '/rest/ai-reviewer/1.0/config/repositories/id/' +
+                encodeURIComponent(repositoryId);
+        }
+        return baseUrl + '/rest/ai-reviewer/1.0/config/repositories/' +
+            encodeURIComponent(projectKey) + '/' + encodeURIComponent(repositorySlug);
+    }
 
     var currentOverrides = {};
 
     function init() {
+        resolveContextFromQuery();
         $('#ai-reviewer-repo-config-form').on('submit', handleSubmit);
         $('#reset-repo-prompt-btn').on('click', handleReset);
         loadConfiguration();
@@ -27,12 +56,19 @@
     }
 
     function handleReset() {
+        $('#repo-prompt-override').val('');
         $('#repo-prompt-append').val('');
         saveConfiguration(buildOverridesPayload());
     }
 
     function buildOverridesPayload() {
         var overrides = $.extend({}, currentOverrides || {});
+        var overrideText = $('#repo-prompt-override').val();
+        if (overrideText && overrideText.trim().length) {
+            overrides['prompt.chunk'] = overrideText;
+        } else {
+            delete overrides['prompt.chunk'];
+        }
         var appendText = $('#repo-prompt-append').val();
         if (appendText && appendText.trim().length) {
             overrides['prompt.chunk.append'] = appendText;
@@ -43,14 +79,20 @@
     }
 
     function loadConfiguration() {
+        if (!repositoryId && (!projectKey || !repositorySlug)) {
+            showMessage('error', 'Failed to load repository configuration: Missing repository context.');
+            return;
+        }
         showLoading(true);
         $.ajax({
-            url: apiUrl,
+            url: buildApiUrl(),
             type: 'GET',
             dataType: 'json',
             success: function(response) {
                 currentOverrides = response && response.overrides ? response.overrides : {};
+                $('#repo-prompt-override').val(currentOverrides['prompt.chunk'] || '');
                 $('#repo-prompt-append').val(currentOverrides['prompt.chunk.append'] || '');
+                updatePromptPreview(response || {});
                 showLoading(false);
             },
             error: function(xhr, status, error) {
@@ -64,13 +106,15 @@
     function saveConfiguration(overrides) {
         showLoading(true);
         $.ajax({
-            url: apiUrl,
+            url: buildApiUrl(),
             type: 'PUT',
             contentType: 'application/json',
             data: JSON.stringify(overrides || {}),
             success: function(response) {
                 currentOverrides = response && response.overrides ? response.overrides : (overrides || {});
+                $('#repo-prompt-override').val(currentOverrides['prompt.chunk'] || '');
                 $('#repo-prompt-append').val(currentOverrides['prompt.chunk.append'] || '');
+                updatePromptPreview(response || {});
                 showMessage('success', 'Repository prompt instructions saved.');
                 showLoading(false);
             },
@@ -99,6 +143,49 @@
             .addClass(type)
             .append($('<p>').text(text));
         $container.append($message);
+    }
+
+    function updatePromptPreview(response) {
+        var defaults = response.defaults || {};
+        var globalConfig = response.global || {};
+        var overrides = response.overrides || {};
+        var effective = response.effective || {};
+        var defaultTemplate = $('#prompt-chunk-default').val() || defaults['prompt.chunk'] || '';
+        var globalTemplate = globalConfig['prompt.chunk'];
+        var repoTemplate = overrides['prompt.chunk'];
+
+        var activeTemplate = repoTemplate || globalTemplate || defaultTemplate;
+        $('#repo-prompt-template-active').val(activeTemplate || '');
+        if (repoTemplate && repoTemplate.trim().length) {
+            $('#repo-prompt-template-source').text('Source: repository override');
+        } else if (globalTemplate && globalTemplate.trim().length) {
+            $('#repo-prompt-template-source').text('Source: global override');
+        } else {
+            $('#repo-prompt-template-source').text('Source: default template');
+        }
+
+        var appendText = effective['prompt.chunk.append'] || '';
+        var effectivePrompt = activeTemplate || '';
+        if (appendText && appendText.trim().length) {
+            effectivePrompt += (effectivePrompt.endsWith('\n') ? '' : '\n') + appendText;
+        }
+        $('#repo-prompt-effective').val(effectivePrompt);
+        autoResizeAll();
+    }
+
+    function autoResizeAll() {
+        ['#repo-prompt-template-active', '#repo-prompt-effective', '#repo-prompt-override', '#repo-prompt-append']
+            .forEach(function(selector) {
+                autoResize($(selector));
+            });
+    }
+
+    function autoResize($textarea) {
+        if (!$textarea || !$textarea.length) {
+            return;
+        }
+        $textarea.css('height', 'auto');
+        $textarea.css('height', $textarea[0].scrollHeight + 12 + 'px');
     }
 
     AJS.toInit(init);

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -11,6 +11,7 @@
         AJS.$('meta[name="projectKey"]').attr('content');
     var repositorySlug = $container.data('repositorySlug') || $container.data('repository-slug') ||
         AJS.$('meta[name="repositorySlug"]').attr('content');
+    var effectivePreviewReady = false;
 
     function resolveContextFromQuery() {
         var params = new URLSearchParams(window.location.search || '');
@@ -44,9 +45,58 @@
 
     function init() {
         resolveContextFromQuery();
+        initMarkupEditors();
         $('#ai-reviewer-repo-config-form').on('submit', handleSubmit);
         $('#reset-repo-prompt-btn').on('click', handleReset);
         loadConfiguration();
+    }
+
+    function initMarkupEditors() {
+        if (typeof require !== 'function') {
+            return;
+        }
+        require(['bitbucket/internal/widget/markup-editor/markup-editor'], function(MarkupEditor) {
+            if (!MarkupEditor || !MarkupEditor.bindTo) {
+                return;
+            }
+            var $overrideEditor = $('#repo-prompt-override-editor');
+            var $appendEditor = $('#repo-prompt-append-editor');
+            var $effectiveEditor = $('#repo-prompt-effective-editor');
+            MarkupEditor.bindTo($overrideEditor);
+            MarkupEditor.bindTo($appendEditor);
+            if ($effectiveEditor.length) {
+                MarkupEditor.bindTo($effectiveEditor);
+                lockEffectivePreview($effectiveEditor);
+                effectivePreviewReady = true;
+            }
+            bindPreviewSpinnerFix($overrideEditor);
+            bindPreviewSpinnerFix($appendEditor);
+            bindPreviewSpinnerFix($effectiveEditor);
+        });
+    }
+
+    function lockEffectivePreview($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        $editor.off('click', '.markup-preview');
+        $editor.off('click', 'textarea');
+        $editor.on('click', '.markup-preview, textarea', function(event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        });
+    }
+
+    function bindPreviewSpinnerFix($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        $editor.on('click', '.markup-preview-button, .markup-preview', function() {
+            var $target = $editor.find('textarea').parent();
+            if ($target && $target.spinStop) {
+                $target.spinStop();
+            }
+        });
     }
 
     function handleSubmit(event) {
@@ -162,11 +212,45 @@
                 '\nADDITIONAL INSTRUCTIONS:\n' + appendText.trim();
         }
         $('#repo-prompt-effective').val(effectivePrompt);
+        triggerEffectivePreview();
         autoResizeAll();
     }
 
+    function triggerEffectivePreview() {
+        if (!effectivePreviewReady) {
+            return;
+        }
+        var $editor = $('#repo-prompt-effective-editor');
+        if (!$editor.length) {
+            return;
+        }
+        var $previewButton = $editor.find('.markup-preview-button');
+        if ($editor.hasClass('previewing')) {
+            return;
+        }
+        if ($previewButton.length) {
+            $previewButton.trigger('click');
+            stopEffectiveSpinner($editor);
+        }
+    }
+
+    function stopEffectiveSpinner($editor) {
+        if (!$editor || !$editor.length) {
+            return;
+        }
+        var $target = $editor.find('textarea').parent();
+        if ($target && $target.spinStop) {
+            $target.spinStop();
+        }
+        setTimeout(function() {
+            if ($target && $target.spinStop) {
+                $target.spinStop();
+            }
+        }, 150);
+    }
+
     function autoResizeAll() {
-        ['#repo-prompt-effective', '#repo-prompt-override', '#repo-prompt-append']
+        ['#repo-prompt-effective']
             .forEach(function(selector) {
                 autoResize($(selector));
             });

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -1,0 +1,105 @@
+(function($) {
+    'use strict';
+
+    var baseUrl = AJS.$('meta[name="application-base-url"]').attr('content') ||
+        AJS.$('meta[name="ajs-context-path"]').attr('content') ||
+        window.location.origin + (AJS.contextPath() || '');
+
+    var $container = $('#ai-reviewer-repo-config');
+    var projectKey = $container.data('project-key');
+    var repositorySlug = $container.data('repository-slug');
+
+    var apiUrl = baseUrl + '/rest/ai-reviewer/1.0/config/repositories/' +
+        encodeURIComponent(projectKey) + '/' + encodeURIComponent(repositorySlug);
+
+    var currentOverrides = {};
+
+    function init() {
+        $('#ai-reviewer-repo-config-form').on('submit', handleSubmit);
+        $('#reset-repo-prompt-btn').on('click', handleReset);
+        loadConfiguration();
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+        var overrides = buildOverridesPayload();
+        saveConfiguration(overrides);
+    }
+
+    function handleReset() {
+        $('#repo-prompt-append').val('');
+        saveConfiguration(buildOverridesPayload());
+    }
+
+    function buildOverridesPayload() {
+        var overrides = $.extend({}, currentOverrides || {});
+        var appendText = $('#repo-prompt-append').val();
+        if (appendText && appendText.trim().length) {
+            overrides['prompt.chunk.append'] = appendText;
+        } else {
+            delete overrides['prompt.chunk.append'];
+        }
+        return overrides;
+    }
+
+    function loadConfiguration() {
+        showLoading(true);
+        $.ajax({
+            url: apiUrl,
+            type: 'GET',
+            dataType: 'json',
+            success: function(response) {
+                currentOverrides = response && response.overrides ? response.overrides : {};
+                $('#repo-prompt-append').val(currentOverrides['prompt.chunk.append'] || '');
+                showLoading(false);
+            },
+            error: function(xhr, status, error) {
+                var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';
+                showMessage('error', 'Failed to load repository configuration: ' + message);
+                showLoading(false);
+            }
+        });
+    }
+
+    function saveConfiguration(overrides) {
+        showLoading(true);
+        $.ajax({
+            url: apiUrl,
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify(overrides || {}),
+            success: function(response) {
+                currentOverrides = response && response.overrides ? response.overrides : (overrides || {});
+                $('#repo-prompt-append').val(currentOverrides['prompt.chunk.append'] || '');
+                showMessage('success', 'Repository prompt instructions saved.');
+                showLoading(false);
+            },
+            error: function(xhr, status, error) {
+                var message = (xhr.responseJSON && xhr.responseJSON.error) || error || 'Unknown error';
+                showMessage('error', 'Failed to save repository prompt instructions: ' + message);
+                showLoading(false);
+            }
+        });
+    }
+
+    function showLoading(isLoading) {
+        $('#loading-indicator').toggle(!!isLoading);
+        $('#save-repo-prompt-btn').prop('disabled', !!isLoading);
+        $('#reset-repo-prompt-btn').prop('disabled', !!isLoading);
+    }
+
+    function showMessage(type, text) {
+        var $container = $('#aui-message-container');
+        $container.empty();
+        if (!text) {
+            return;
+        }
+        var $message = $('<div>')
+            .addClass('aui-message')
+            .addClass(type)
+            .append($('<p>').text(text));
+        $container.append($message);
+    }
+
+    AJS.toInit(init);
+})(AJS.$);

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -240,13 +240,19 @@
             return;
         }
         var $previewButton = $editor.find('.markup-preview-button');
-        if ($editor.hasClass('previewing')) {
+        if (!$previewButton.length) {
             return;
         }
-        if ($previewButton.length) {
+        if ($editor.hasClass('previewing')) {
             $previewButton.trigger('click');
-            stopSpinnerForEditor($editor);
+            setTimeout(function() {
+                $previewButton.trigger('click');
+                stopSpinnerForEditor($editor);
+            }, 0);
+            return;
         }
+        $previewButton.trigger('click');
+        stopSpinnerForEditor($editor);
     }
 
     function autoResizeAll() {

--- a/src/main/resources/js/ai-reviewer-repo-settings.js
+++ b/src/main/resources/js/ai-reviewer-repo-settings.js
@@ -153,19 +153,10 @@
         var defaultTemplate = $('#prompt-chunk-default').val() || defaults['prompt.chunk'] || '';
         var globalTemplate = globalConfig['prompt.chunk'];
         var repoTemplate = overrides['prompt.chunk'];
-
-        var activeTemplate = repoTemplate || globalTemplate || defaultTemplate;
-        $('#repo-prompt-template-active').val(activeTemplate || '');
-        if (repoTemplate && repoTemplate.trim().length) {
-            $('#repo-prompt-template-source').text('Source: repository override');
-        } else if (globalTemplate && globalTemplate.trim().length) {
-            $('#repo-prompt-template-source').text('Source: global override');
-        } else {
-            $('#repo-prompt-template-source').text('Source: default template');
-        }
+        var baseTemplate = repoTemplate || globalTemplate || defaultTemplate;
 
         var appendText = effective['prompt.chunk.append'] || '';
-        var effectivePrompt = activeTemplate || '';
+        var effectivePrompt = baseTemplate || '';
         if (appendText && appendText.trim().length) {
             effectivePrompt += (effectivePrompt.endsWith('\n') ? '' : '\n') + appendText;
         }
@@ -174,7 +165,7 @@
     }
 
     function autoResizeAll() {
-        ['#repo-prompt-template-active', '#repo-prompt-effective', '#repo-prompt-override', '#repo-prompt-append']
+        ['#repo-prompt-effective', '#repo-prompt-override', '#repo-prompt-append']
             .forEach(function(selector) {
                 autoResize($(selector));
             });

--- a/src/main/resources/prompts/chunk-instructions-template.txt
+++ b/src/main/resources/prompts/chunk-instructions-template.txt
@@ -21,14 +21,5 @@ SEVERITY GUIDELINES:
 - MEDIUM: Maintainability problems, moderate performance issues, code-quality gaps
 - LOW: Style inconsistencies, documentation gaps, minor optimisations
 
-CRITICAL INSTRUCTIONS:
-1. Hunt for subtle bugs that can trigger runtime failures in NEW code.
-2. Flag any security vulnerabilities introduced on ADDED lines.
-3. Evaluate performance impact of the NEW changes (algorithmic or resource usage).
-4. Skip reporting if confidence is low or evidence is missing.
-5. Never infer line numbers—only use explicit [Line N] tags.
-6. The `problematicCode` object MUST contain the exact added diff lines (including [Line N] markers) that demonstrate the issue.
-7. If no specific lines apply, set `problematicCode.snippet` to an empty string.
-
 Diff chunk:
 {{ANNOTATED_DIFF}}

--- a/src/main/resources/prompts/system-prompt.txt
+++ b/src/main/resources/prompts/system-prompt.txt
@@ -7,3 +7,15 @@ You are an AI code reviewer. Follow all policy rules:
 - For each issue include the exact added diff lines (with [Line N] markers) in `problematicCode.snippet`. Do not paraphrase.
 - Set `problematicCode.lineStart` to the smallest [Line N] value in the snippet and `problematicCode.lineEnd` to the largest [Line N].
 - Respond ONLY with JSON that validates against the supplied schema. No extra commentary.
+
+Critical instructions for correct operation:
+1. Hunt for subtle bugs that can trigger runtime failures in NEW code.
+2. Flag any security vulnerabilities introduced on ADDED lines.
+3. Evaluate performance impact of the NEW changes (algorithmic or resource usage).
+4. Skip reporting if confidence is low or evidence is missing.
+5. Never infer line numbers—only use explicit [Line N] tags.
+6. The `problematicCode` object MUST contain the exact added diff lines (including [Line N] markers) that demonstrate the issue.
+7. If no specific lines apply, set `problematicCode.snippet` to an empty string.
+
+{{ADDITIONAL_INSTRUCTIONS}}
+

--- a/src/main/resources/templates/admin-config.vm
+++ b/src/main/resources/templates/admin-config.vm
@@ -400,6 +400,18 @@
 
                         <div class="field-group">
                             <div class="checkbox">
+                                <input class="checkbox" type="checkbox" id="verbose-mode"
+                                       name="verboseMode"
+                                       #if($verboseMode)checked="checked"#end>
+                                <label for="verbose-mode">Enable Verbose Mode</label>
+                            </div>
+                            <div class="description">
+                                When enabled, prompt payloads and related metadata are written to the filesystem for troubleshooting.
+                            </div>
+                        </div>
+
+                        <div class="field-group">
+                            <div class="checkbox">
                                 <input class="checkbox" type="checkbox" id="auto-approve" name="autoApprove"
                                        #if($autoApprove)checked#end>
                                 <label for="auto-approve">Auto-approve when only low severity issues remain</label>

--- a/src/main/resources/templates/admin-prompts.vm
+++ b/src/main/resources/templates/admin-prompts.vm
@@ -28,12 +28,46 @@
 
                         <div class="field-group">
                             <label for="prompt-system-effective">Effective System Prompt</label>
-                            <textarea class="text long-field" id="prompt-system-effective" rows="16" readonly>$promptSystemEffective</textarea>
+                            <div class="markup-editor preview-only" id="prompt-system-effective-editor">
+                                <div class="markup-preview markup"></div>
+                                <textarea class="text expanding" id="prompt-system-effective" rows="16" readonly>$promptSystemEffective</textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary"></div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                         </div>
 
                         <div class="field-group">
                             <label for="prompt-chunk-effective">Effective User Prompt</label>
-                            <textarea class="text long-field" id="prompt-chunk-effective" rows="18" readonly>$promptChunkEffective</textarea>
+                            <div class="markup-editor preview-only" id="prompt-chunk-effective-editor">
+                                <div class="markup-preview markup"></div>
+                                <textarea class="text expanding" id="prompt-chunk-effective" rows="18" readonly>$promptChunkEffective</textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary"></div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                         </div>
 
                         <h2>Modify Prompts</h2>
@@ -41,13 +75,57 @@
 
                         <div class="field-group">
                             <label for="prompt-chunk">User Prompt Override</label>
-                            <textarea class="text long-field" id="prompt-chunk" rows="18">$!promptChunkOverride</textarea>
+                            <div class="markup-editor" id="prompt-chunk-editor">
+                                <div class="markup-preview markup" title="Click to edit"></div>
+                                <textarea class="text expanding" id="prompt-chunk" rows="18">$!promptChunkOverride</textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary">
+                                        <label class="aui-button-subtle aui-button-compact markup-attachments-button"
+                                               title="Attach file" role="button" tabindex="0">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-attachment"></span>
+                                        </label>
+                                    </div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                             <div class="description">Leave blank to use the default user prompt template.</div>
                         </div>
 
                         <div class="field-group">
                             <label for="prompt-system-append">System Prompt Additions</label>
-                            <textarea class="text long-field" id="prompt-system-append" rows="10">$!promptSystemAppend</textarea>
+                            <div class="markup-editor" id="prompt-system-append-editor">
+                                <div class="markup-preview markup" title="Click to edit"></div>
+                                <textarea class="text expanding" id="prompt-system-append" rows="10">$!promptSystemAppend</textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary">
+                                        <label class="aui-button-subtle aui-button-compact markup-attachments-button"
+                                               title="Attach file" role="button" tabindex="0">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-attachment"></span>
+                                        </label>
+                                    </div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                             <div class="description">Additional text appended to the default system prompt.</div>
                         </div>
 

--- a/src/main/resources/templates/admin-prompts.vm
+++ b/src/main/resources/templates/admin-prompts.vm
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>AI Code Reviewer - Prompt Customisation</title>
+    <meta name="decorator" content="atl.admin">
+    <meta name="application-base-url" content="$baseUrl">
+    $webResourceManager.requireResource("com.teknolojikpanda.bitbucket.ai-code-reviewer:ai-reviewer-prompts-resources")
+</head>
+<body>
+    <header class="aui-page-header" style="padding-bottom: 20px;">
+        <div class="aui-page-header-inner">
+            <div class="aui-page-header-main">
+                <h1>AI Code Reviewer Prompt Customisation</h1>
+                <p class="aui-page-header-description">Edit active prompts and review effective values.</p>
+            </div>
+        </div>
+    </header>
+
+    <div class="aui-page-panel">
+        <div class="aui-page-panel-inner">
+            <section class="aui-page-panel-content">
+                <div id="ai-reviewer-prompts-container">
+                    <div id="aui-message-container"></div>
+
+                    <form id="ai-reviewer-prompts-form" class="aui">
+                        <h2>Active Prompts</h2>
+                        <p class="description">These are the prompts currently sent to the model (after applying defaults and append instructions).</p>
+
+                        <div class="field-group">
+                            <label for="prompt-system-effective">Effective System Prompt</label>
+                            <textarea class="text long-field" id="prompt-system-effective" rows="16" readonly>$promptSystemEffective</textarea>
+                        </div>
+
+                        <div class="field-group">
+                            <label for="prompt-chunk-effective">Effective User Prompt</label>
+                            <textarea class="text long-field" id="prompt-chunk-effective" rows="18" readonly>$promptChunkEffective</textarea>
+                        </div>
+
+                        <h2>Modify Prompts</h2>
+                        <p class="description">Override the user prompt or append extra system instructions.</p>
+
+                        <div class="field-group">
+                            <label for="prompt-chunk">User Prompt Override</label>
+                            <textarea class="text long-field" id="prompt-chunk" rows="18">$!promptChunkOverride</textarea>
+                            <div class="description">Leave blank to use the default user prompt template.</div>
+                        </div>
+
+                        <div class="field-group">
+                            <label for="prompt-system-append">System Prompt Additions</label>
+                            <textarea class="text long-field" id="prompt-system-append" rows="10">$!promptSystemAppend</textarea>
+                            <div class="description">Additional text appended to the default system prompt.</div>
+                        </div>
+
+                        <textarea id="prompt-system-default" class="hidden">$promptSystemDefault</textarea>
+                        <textarea id="prompt-chunk-default" class="hidden">$promptChunkDefault</textarea>
+
+                        <div class="buttons-container">
+                            <div class="buttons">
+                                <button type="submit" id="save-prompts-btn" class="aui-button aui-button-primary">
+                                    <span class="aui-icon aui-icon-small aui-iconfont-success"></span> Save Prompts
+                                </button>
+                                <button type="button" id="reset-prompts-btn" class="aui-button">
+                                    <span class="aui-icon aui-icon-small aui-iconfont-undo"></span> Reset to Defaults
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+
+                    <div id="loading-indicator" class="aui-spinner" style="display: none;"></div>
+                </div>
+            </section>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/repo-config.vm
+++ b/src/main/resources/templates/repo-config.vm
@@ -32,15 +32,6 @@
                     <div id="aui-message-container"></div>
 
                     <form id="ai-reviewer-repo-config-form" class="aui">
-                        <h2>Active Prompt Template</h2>
-                        <p class="description">This is the user prompt template currently applied to this repository.</p>
-
-                        <div class="field-group">
-                            <label for="repo-prompt-template-active">Active user prompt template</label>
-                            <textarea class="text long-field" id="repo-prompt-template-active" rows="12" readonly></textarea>
-                            <div class="description" id="repo-prompt-template-source"></div>
-                        </div>
-
                         <div class="field-group">
                             <label for="repo-prompt-effective">Effective user prompt</label>
                             <textarea class="text long-field" id="repo-prompt-effective" rows="12" readonly></textarea>

--- a/src/main/resources/templates/repo-config.vm
+++ b/src/main/resources/templates/repo-config.vm
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>AI Code Reviewer - Repository Prompt Settings</title>
+    <meta name="decorator" content="bitbucket.repository.settings">
+    <meta name="application-base-url" content="$baseUrl">
+    $webResourceManager.requireResource("com.teknolojikpanda.bitbucket.ai-code-reviewer:ai-reviewer-repo-settings-resources")
+</head>
+<body>
+    <header class="aui-page-header" style="padding-bottom: 20px;">
+        <div class="aui-page-header-inner">
+            <div class="aui-page-header-main">
+                <h1>AI Code Reviewer Prompt Settings</h1>
+                <p class="aui-page-header-description">
+                    $projectName / $repositoryName
+                </p>
+            </div>
+        </div>
+    </header>
+
+    <div class="aui-page-panel">
+        <div class="aui-page-panel-inner">
+            <section class="aui-page-panel-content">
+                <div id="ai-reviewer-repo-config"
+                     data-project-key="$projectKey"
+                     data-repository-slug="$repositorySlug">
+
+                    <div id="aui-message-container"></div>
+
+                    <form id="ai-reviewer-repo-config-form" class="aui">
+                        <h2>Additional User Prompt Instructions</h2>
+                        <p class="description">
+                            These instructions are appended to the user prompt for this repository only. The base prompt comes from the global
+                            configuration and bundled templates.
+                        </p>
+
+                        <div class="field-group">
+                            <label for="repo-prompt-append">Repository-specific instructions</label>
+                            <textarea class="text long-field" id="repo-prompt-append" rows="8"></textarea>
+                            <div class="description">Leave blank to inherit the global prompt without repository-specific instructions.</div>
+                        </div>
+
+                        <div class="buttons-container">
+                            <div class="buttons">
+                                <button type="submit" id="save-repo-prompt-btn" class="aui-button aui-button-primary">
+                                    <span class="aui-icon aui-icon-small aui-iconfont-success"></span> Save Prompt Instructions
+                                </button>
+                                <button type="button" id="reset-repo-prompt-btn" class="aui-button">
+                                    <span class="aui-icon aui-icon-small aui-iconfont-undo"></span> Reset to Global Prompt
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+
+                    <div id="loading-indicator" class="aui-spinner" style="display: none;"></div>
+                </div>
+            </section>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/repo-config.vm
+++ b/src/main/resources/templates/repo-config.vm
@@ -34,7 +34,24 @@
                     <form id="ai-reviewer-repo-config-form" class="aui">
                         <div class="field-group">
                             <label for="repo-prompt-effective">Effective user prompt</label>
-                            <textarea class="text long-field" id="repo-prompt-effective" rows="12" readonly></textarea>
+                            <div class="markup-editor preview-only" id="repo-prompt-effective-editor">
+                                <div class="markup-preview markup"></div>
+                                <textarea class="text expanding" id="repo-prompt-effective" rows="12" readonly></textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary"></div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                             <div class="description">Includes any repository or global append instructions.</div>
                         </div>
 
@@ -45,7 +62,29 @@
 
                         <div class="field-group">
                             <label for="repo-prompt-override">Repository-specific user prompt</label>
-                            <textarea class="text long-field" id="repo-prompt-override" rows="12"></textarea>
+                            <div class="markup-editor" id="repo-prompt-override-editor">
+                                <div class="markup-preview markup" title="Click to edit"></div>
+                                <textarea class="text expanding" id="repo-prompt-override" rows="12"></textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary">
+                                        <label class="aui-button-subtle aui-button-compact markup-attachments-button"
+                                               title="Attach file" role="button" tabindex="0">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-attachment"></span>
+                                        </label>
+                                    </div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                             <div class="description">Leave blank to use the global user prompt template.</div>
                         </div>
 
@@ -59,7 +98,29 @@
 
                         <div class="field-group">
                             <label for="repo-prompt-append">Repository-specific instructions</label>
-                            <textarea class="text long-field" id="repo-prompt-append" rows="8"></textarea>
+                            <div class="markup-editor" id="repo-prompt-append-editor">
+                                <div class="markup-preview markup" title="Click to edit"></div>
+                                <textarea class="text expanding" id="repo-prompt-append" rows="8"></textarea>
+                                <div class="markup-toolbar">
+                                    <div class="secondary">
+                                        <a class="aui-button aui-button-subtle aui-button-compact markup-preview-help"
+                                           href="https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html"
+                                           target="_blank"
+                                           title="Markdown syntax guide">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-question-circle"></span>
+                                        </a>
+                                        <button type="button" class="aui-button aui-button-compact markup-preview-button"
+                                                data-preview-tooltip="Preview">Preview</button>
+                                    </div>
+                                    <div class="primary">
+                                        <label class="aui-button-subtle aui-button-compact markup-attachments-button"
+                                               title="Attach file" role="button" tabindex="0">
+                                            <span class="aui-icon aui-icon-small aui-iconfont-attachment"></span>
+                                        </label>
+                                    </div>
+                                    <div class="tertiary"></div>
+                                </div>
+                            </div>
                             <div class="description">Leave blank to inherit the global prompt without repository-specific instructions.</div>
                         </div>
 

--- a/src/main/resources/templates/repo-config.vm
+++ b/src/main/resources/templates/repo-config.vm
@@ -3,6 +3,9 @@
 <head>
     <title>AI Code Reviewer - Repository Prompt Settings</title>
     <meta name="decorator" content="bitbucket.repository.settings">
+    <meta name="projectKey" content="$projectKey">
+    <meta name="repositorySlug" content="$repositorySlug">
+    <meta name="activeTab" content="ai-reviewer-repo-settings-link">
     <meta name="application-base-url" content="$baseUrl">
     $webResourceManager.requireResource("com.teknolojikpanda.bitbucket.ai-code-reviewer:ai-reviewer-repo-settings-resources")
 </head>
@@ -23,11 +26,40 @@
             <section class="aui-page-panel-content">
                 <div id="ai-reviewer-repo-config"
                      data-project-key="$projectKey"
-                     data-repository-slug="$repositorySlug">
+                 data-repository-slug="$repositorySlug"
+                 data-repository-id="$repositoryId">
 
                     <div id="aui-message-container"></div>
 
                     <form id="ai-reviewer-repo-config-form" class="aui">
+                        <h2>Active Prompt Template</h2>
+                        <p class="description">This is the user prompt template currently applied to this repository.</p>
+
+                        <div class="field-group">
+                            <label for="repo-prompt-template-active">Active user prompt template</label>
+                            <textarea class="text long-field" id="repo-prompt-template-active" rows="12" readonly></textarea>
+                            <div class="description" id="repo-prompt-template-source"></div>
+                        </div>
+
+                        <div class="field-group">
+                            <label for="repo-prompt-effective">Effective user prompt</label>
+                            <textarea class="text long-field" id="repo-prompt-effective" rows="12" readonly></textarea>
+                            <div class="description">Includes any repository or global append instructions.</div>
+                        </div>
+
+                        <h2>User Prompt Override</h2>
+                        <p class="description">
+                            Override the user prompt for this repository only. Leave blank to inherit the global prompt template.
+                        </p>
+
+                        <div class="field-group">
+                            <label for="repo-prompt-override">Repository-specific user prompt</label>
+                            <textarea class="text long-field" id="repo-prompt-override" rows="12"></textarea>
+                            <div class="description">Leave blank to use the global user prompt template.</div>
+                        </div>
+
+                        <textarea id="prompt-chunk-default" class="hidden">$promptChunkDefault</textarea>
+
                         <h2>Additional User Prompt Instructions</h2>
                         <p class="description">
                             These instructions are appended to the user prompt for this repository only. The base prompt comes from the global

--- a/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
+++ b/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ReviewConfigFactoryTest {
 
@@ -46,5 +47,20 @@ public class ReviewConfigFactoryTest {
         assertEquals(4, reviewConfig.getOverviewMaxRetries());
         assertEquals(2500, reviewConfig.getChunkRetryDelayMs());
         assertEquals(2500, reviewConfig.getOverviewRetryDelayMs());
+    }
+
+    @Test
+    public void appliesPromptOverridesAndAppends() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("prompt.chunk", "USER_PROMPT");
+        config.put("prompt.chunk.append", "REPO_APPEND");
+        config.put("prompt.system.append", "SYSTEM_APPEND");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertEquals("USER_PROMPT\nREPO_APPEND",
+                reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
+        String systemPrompt = reviewConfig.getPromptTemplates().getSystemPrompt();
+        assertTrue(systemPrompt.endsWith("SYSTEM_APPEND"));
     }
 }

--- a/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
+++ b/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ReviewConfigFactoryTest {
@@ -54,13 +55,113 @@ public class ReviewConfigFactoryTest {
         Map<String, Object> config = new HashMap<>();
         config.put("prompt.chunk", "USER_PROMPT");
         config.put("prompt.chunk.append", "REPO_APPEND");
+        config.put("prompt.system", "SYSTEM_PROMPT");
         config.put("prompt.system.append", "SYSTEM_APPEND");
 
         ReviewConfig reviewConfig = factory.from(config);
 
-    assertEquals("USER_PROMPT\nADDITIONAL INSTRUCTIONS:\nREPO_APPEND",
+        assertEquals("USER_PROMPT\nADDITIONAL INSTRUCTIONS:\nREPO_APPEND",
                 reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
-        String systemPrompt = reviewConfig.getPromptTemplates().getSystemPrompt();
-        assertTrue(systemPrompt.endsWith("SYSTEM_APPEND"));
+        assertEquals("SYSTEM_PROMPT\nADDITIONAL INSTRUCTIONS:\nSYSTEM_APPEND",
+                reviewConfig.getPromptTemplates().getSystemPrompt());
+    }
+
+    @Test
+    public void whitespaceOnlyAppendsAreIgnoredAndPlaceholderRemoved() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("prompt.chunk", "CHUNK BASE {{ADDITIONAL_INSTRUCTIONS}}");
+        config.put("prompt.chunk.append", "   \t  ");
+        config.put("prompt.system", "SYSTEM BASE {{ADDITIONAL_INSTRUCTIONS}}");
+        config.put("prompt.system.append", "\n  ");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertEquals("CHUNK BASE", reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
+        assertEquals("SYSTEM BASE", reviewConfig.getPromptTemplates().getSystemPrompt());
+    }
+
+    @Test
+    public void placeholderRemovedWhenNoAppendProvided() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("prompt.chunk", "CHUNK NO APPEND {{ADDITIONAL_INSTRUCTIONS}}");
+        config.put("prompt.system", "SYSTEM NO APPEND {{ADDITIONAL_INSTRUCTIONS}}");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertEquals("CHUNK NO APPEND", reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
+        assertEquals("SYSTEM NO APPEND", reviewConfig.getPromptTemplates().getSystemPrompt());
+    }
+
+    @Test
+    public void appendsAddedWhenPlaceholderMissing() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("prompt.chunk", "CHUNK WITHOUT PLACEHOLDER");
+        config.put("prompt.chunk.append", "CHUNK APPEND");
+        config.put("prompt.system", "SYSTEM WITHOUT PLACEHOLDER");
+        config.put("prompt.system.append", "SYSTEM APPEND");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertEquals("CHUNK WITHOUT PLACEHOLDER\nADDITIONAL INSTRUCTIONS:\nCHUNK APPEND",
+                reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
+        assertEquals("SYSTEM WITHOUT PLACEHOLDER\nADDITIONAL INSTRUCTIONS:\nSYSTEM APPEND",
+                reviewConfig.getPromptTemplates().getSystemPrompt());
+    }
+
+    @Test
+    public void onlyChunkAppendDoesNotAffectSystemPrompt() {
+        Map<String, Object> baseConfig = new HashMap<>();
+        baseConfig.put("prompt.chunk", "BASE CHUNK");
+        baseConfig.put("prompt.system", "BASE SYSTEM");
+
+        ReviewConfig baseReviewConfig = factory.from(baseConfig);
+
+        Map<String, Object> config = new HashMap<>(baseConfig);
+        config.put("prompt.chunk.append", "CHUNK ONLY APPEND");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertEquals("BASE CHUNK\nADDITIONAL INSTRUCTIONS:\nCHUNK ONLY APPEND",
+                reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
+        assertEquals(baseReviewConfig.getPromptTemplates().getSystemPrompt(),
+                reviewConfig.getPromptTemplates().getSystemPrompt());
+    }
+
+    @Test
+    public void onlySystemAppendDoesNotAffectChunkPrompt() {
+        Map<String, Object> baseConfig = new HashMap<>();
+        baseConfig.put("prompt.chunk", "BASE CHUNK");
+        baseConfig.put("prompt.system", "BASE SYSTEM");
+
+        ReviewConfig baseReviewConfig = factory.from(baseConfig);
+
+        Map<String, Object> config = new HashMap<>(baseConfig);
+        config.put("prompt.system.append", "SYSTEM ONLY APPEND");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertEquals(baseReviewConfig.getPromptTemplates().getChunkInstructionsTemplate(),
+                reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
+        assertEquals("BASE SYSTEM\nADDITIONAL INSTRUCTIONS:\nSYSTEM ONLY APPEND",
+                reviewConfig.getPromptTemplates().getSystemPrompt());
+    }
+
+    @Test
+    public void verboseModeDefaultsToFalseWhenAbsent() {
+        Map<String, Object> config = new HashMap<>();
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertFalse(reviewConfig.isVerboseMode());
+    }
+
+    @Test
+    public void verboseModeIsTrueWhenConfigured() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("verboseMode", true);
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        assertTrue(reviewConfig.isVerboseMode());
     }
 }

--- a/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
+++ b/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
@@ -58,7 +58,7 @@ public class ReviewConfigFactoryTest {
 
         ReviewConfig reviewConfig = factory.from(config);
 
-        assertEquals("USER_PROMPT\nREPO_APPEND",
+    assertEquals("USER_PROMPT\nADDITIONAL INSTRUCTIONS:\nREPO_APPEND",
                 reviewConfig.getPromptTemplates().getChunkInstructionsTemplate());
         String systemPrompt = reviewConfig.getPromptTemplates().getSystemPrompt();
         assertTrue(systemPrompt.endsWith("SYSTEM_APPEND"));

--- a/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
+++ b/src/test/java/com/teknolojikpanda/bitbucket/aicode/core/ReviewConfigFactoryTest.java
@@ -109,6 +109,23 @@ public class ReviewConfigFactoryTest {
     }
 
     @Test
+    public void appliesAppendsToDefaultTemplatesWhenNoOverridesProvided() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("prompt.system.append", "SYSTEM APPEND");
+        config.put("prompt.chunk.append", "CHUNK APPEND");
+
+        ReviewConfig reviewConfig = factory.from(config);
+
+        String systemPrompt = reviewConfig.getPromptTemplates().getSystemPrompt();
+        String chunkPrompt = reviewConfig.getPromptTemplates().getChunkInstructionsTemplate();
+
+        assertTrue(systemPrompt.contains("ADDITIONAL INSTRUCTIONS:"));
+        assertTrue(systemPrompt.contains("SYSTEM APPEND"));
+        assertTrue(chunkPrompt.contains("ADDITIONAL INSTRUCTIONS:"));
+        assertTrue(chunkPrompt.contains("CHUNK APPEND"));
+    }
+
+    @Test
     public void onlyChunkAppendDoesNotAffectSystemPrompt() {
         Map<String, Object> baseConfig = new HashMap<>();
         baseConfig.put("prompt.chunk", "BASE CHUNK");


### PR DESCRIPTION
Özet

- Repo ayarlarında “AI Code Reviewer Prompt Settings” sayfası için effective user prompt preview-only native Bitbucket editörüne taşındı.
- Admin “Prompt Customisation” sayfasında effective system/user prompt alanları native editör ve preview-only moda alındı.
Preview/edit toggle, spinner ve expandingText artefaktları bastırıldı.
- Prompt yönetimi için admin/repo dokümantasyonu güncellendi.

Testler

mvn -q test

Notlar

- Effective prompt alanları artık sadece önizleme; toolbar/textarea görünmez.

## Summary by Sourcery

Add configurable prompt overrides and verbose logging for AI Code Reviewer along with new admin and repository UI for managing prompts.

New Features:
- Introduce admin-level Prompt Customisation page with native Bitbucket markup editor and preview-only effective prompts.
- Add repository-level AI Code Reviewer Prompt Settings page for overriding and appending user prompts.
- Support additional prompt configuration keys including prompt.system.append and prompt.chunk.append, and wire them into prompt rendering.

Enhancements:
- Persist prompt override and append fields in AIReviewConfiguration and expose them via configuration service and REST API.
- Adjust prompt loading to apply append instructions and ignore empty overrides while keeping placeholders consistent.
- Add verboseMode flag to configuration and propagate it into ReviewConfig and Ollama client behavior.

Documentation:
- Document verboseMode behavior and new prompt configuration keys and UI flows in the configuration, admin, and user guides.

Tests:
- Extend ReviewConfigFactory tests to cover prompt append behavior, placeholder handling, and verboseMode defaults.